### PR TITLE
Fix for KeyNotFoundException in Erase method of LineSeries

### DIFF
--- a/LiveChartsCore/Series/LineSeries.cs
+++ b/LiveChartsCore/Series/LineSeries.cs
@@ -485,18 +485,24 @@ namespace LiveCharts
                         if (_isPrimitive)
                         {
                             var i = s.ChartPoint.Key;
-                            var l = _primitiveDictionary[i];
-                            Chart.DrawMargin.Children.Remove(l);
-                            Shapes.Remove(l);
-                            _dictionary.Remove(i);
+                            Line l;
+                            if (_primitiveDictionary.TryGetValue(i, out l))
+                            {
+                                Chart.DrawMargin.Children.Remove(l);
+                                Shapes.Remove(l);
+                                _primitiveDictionary.Remove(i);
+                            }
                         }
                         else
                         {
                             var i = s.ChartPoint.Instance;
-                            var l = _dictionary[i];
-                            Chart.DrawMargin.Children.Remove(l);
-                            Shapes.Remove(l);
-                            _dictionary.Remove(i);
+                            Line l;
+                            if (_dictionary.TryGetValue(i, out l))
+                            {
+                                Chart.DrawMargin.Children.Remove(l);
+                                Shapes.Remove(l);
+                                _dictionary.Remove(i);
+                            }
                         }
                     }
                 }

--- a/LiveChartsCore/Series/LineSeries.cs
+++ b/LiveChartsCore/Series/LineSeries.cs
@@ -492,6 +492,12 @@ namespace LiveCharts
                                 Shapes.Remove(l);
                                 _primitiveDictionary.Remove(i);
                             }
+                            else
+                            {
+#if DEBUG
+                                System.Diagnostics.Trace.TraceWarning("Could not find ChartPoint with key '{0}' in primitives dictionary", i);
+#endif
+                            }
                         }
                         else
                         {
@@ -502,6 +508,12 @@ namespace LiveCharts
                                 Chart.DrawMargin.Children.Remove(l);
                                 Shapes.Remove(l);
                                 _dictionary.Remove(i);
+                            }
+                            else
+                            {
+#if DEBUG
+                                System.Diagnostics.Trace.TraceWarning("Could not find ChartPoint instance '{0}' in dictionary", i);
+#endif
                             }
                         }
                     }


### PR DESCRIPTION
I got this exception while playing with the WPF demo project. Just found two things, first wrong removing ChartPoint from _primitiveDictionary and second the exception itself.
Just use the TryGetValue method and add some logging for the mistake, cause maybe the reason comes from other stuff.

![2016-02-11_09h59_06](https://cloud.githubusercontent.com/assets/658431/12972921/59f57afc-d0a9-11e5-93fa-7bf0428da69d.png)
