### PR TITLE
minor fix, avoid early initialization state setting 

### DIFF
--- a/LiveChartsCore/CoreComponents/Chart.cs
+++ b/LiveChartsCore/CoreComponents/Chart.cs
@@ -1024,7 +1024,7 @@ namespace LiveCharts.CoreComponents
 
         private void PrepareCanvas(bool ereaseAll = false)
         {
-            if (Series == null) return;
+            if (Series == null || Series.Count==0) return;
             if (!SeriesInitialized) InitializeSeries(this);
 
             if (AxisY.Parent == null) Canvas.Children.Add(AxisY);
@@ -1080,7 +1080,7 @@ namespace LiveCharts.CoreComponents
         {
             var chart = o as Chart;
 
-            if (chart == null || chart.Series == null) return;
+            if (chart == null || chart.Series == null || chart.Series.Count == 0) return;
             if (chart.Series.Any(x => x == null)) return;
 
             if (chart.Series.Count > 0 && !chart.HasInvalidArea) chart.Scale();


### PR DESCRIPTION
Series is not null per construction, line in the ctor is
SetCurrentValue(SeriesProperty, new SeriesCollection(defaultConfig));
InitializeSeries was called once with empty Series. Then it was not called anymore when actual value was set.
