### PR TITLE
Forward mouse events from the pie slice text labels so they are not lost

### DIFF
--- a/LiveChartsCore/Series/PieSeries.cs
+++ b/LiveChartsCore/Series/PieSeries.cs
@@ -149,6 +149,11 @@ namespace LiveCharts
                         {
                             tb.Visibility = Visibility.Visible;
                         }
+
+                        // Forward mouse events from the TextBlock to the PointShape so they are not lost
+                        tb.MouseDown += (sender, e) => visual.PointShape.RaiseEvent(e);
+                        tb.MouseEnter += (sender, e) => visual.PointShape.RaiseEvent(e);
+                        tb.MouseLeave += (sender, e) => visual.PointShape.RaiseEvent(e);
                     }
                 }
 


### PR DESCRIPTION
When PieSeries.DataLabels=True, this allows the Chart.DataClick event to be fired when clicking on the label just like clicking on the pie slice.  It also prevents the slice animation from resetting when mousing over the label.

