### PR TITLE
Fixed null exception on Application.Current

### DIFF
--- a/LiveChartsCore/Cache/AxisSeparationCache.cs
+++ b/LiveChartsCore/Cache/AxisSeparationCache.cs
@@ -124,14 +124,22 @@ namespace LiveCharts.Cache
                 Duration = _anSpeed
             };
 
-            anim.Completed += (sender, args) =>
+            if (Application.Current == null)
             {
-                Application.Current.Dispatcher.Invoke(new Action(() =>
+                chart.Canvas.Children.Remove(TextBlock);
+                chart.Canvas.Children.Remove(Line);
+            }
+            else
+            {
+                anim.Completed += (sender, args) =>
                 {
-                    chart.Canvas.Children.Remove(TextBlock);
-                    chart.Canvas.Children.Remove(Line);
-                }));
-            };
+                    Application.Current.Dispatcher.Invoke(new Action(() =>
+                    {
+                        chart.Canvas.Children.Remove(TextBlock);
+                        chart.Canvas.Children.Remove(Line);
+                    }));
+                };
+            }
 
             TextBlock.BeginAnimation(UIElement.OpacityProperty, anim);
             Line.BeginAnimation(UIElement.OpacityProperty, new DoubleAnimation(1, 0, _anSpeed));

--- a/LiveChartsCore/Cache/AxisSeparationCache.cs
+++ b/LiveChartsCore/Cache/AxisSeparationCache.cs
@@ -110,10 +110,15 @@ namespace LiveCharts.Cache
 
         private void Remove(Chart chart, Axis axis)
         {
-            if (axis.DisableAnimations || chart.DisableAnimations)
+            Action removeComponents = () =>
             {
                 chart.Canvas.Children.Remove(TextBlock);
                 chart.Canvas.Children.Remove(Line);
+            };
+
+            if (axis.DisableAnimations || chart.DisableAnimations)
+            {
+                removeComponents();
                 return;
             }
 
@@ -123,21 +128,17 @@ namespace LiveCharts.Cache
                 To = 0,
                 Duration = _anSpeed
             };
+            
 
             if (Application.Current == null)
             {
-                chart.Canvas.Children.Remove(TextBlock);
-                chart.Canvas.Children.Remove(Line);
+                removeComponents();
             }
             else
             {
                 anim.Completed += (sender, args) =>
                 {
-                    Application.Current.Dispatcher.Invoke(new Action(() =>
-                    {
-                        chart.Canvas.Children.Remove(TextBlock);
-                        chart.Canvas.Children.Remove(Line);
-                    }));
+                    Application.Current.Dispatcher.Invoke(removeComponents);
                 };
             }
 

--- a/UnitTesting/UnitTesting.csproj
+++ b/UnitTesting/UnitTesting.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitTesting</RootNamespace>
     <AssemblyName>UnitTesting</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/WPFExamples/z.DebugCases/101/ViewModel.cs
+++ b/WPFExamples/z.DebugCases/101/ViewModel.cs
@@ -23,7 +23,10 @@ namespace ChartsTest.z.DebugCases._101
         [NotifyPropertyChangedInvocator]
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            if (PropertyChanged != null)
+            {
+                PropertyChanged.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            }
         }
     }
 }


### PR DESCRIPTION
When the method, "Remove", on the AxisSeparationCache class is called from a WinForms application, the Current Application is null. 

To fix this, I added a null check before invoking the method.

Since I'm using an old version of visual studio (2013), I needed to change the version of the unit tests .net framework so that the solution would be compatible with my environment.