### PR TITLE
Portable

### DIFF
--- a/Core/AxisCore.cs
+++ b/Core/AxisCore.cs
@@ -37,6 +37,8 @@ namespace LiveCharts
             View = view;
             CleanFactor = 3;
             Cache = new Dictionary<double, SeparatorElementCore>();
+            LastAxisMax = null;
+            LastAxisMin = null;
         }
 
         #endregion
@@ -140,7 +142,9 @@ namespace LiveCharts
             var deltaX = p2.X - p1.X;
             // ReSharper disable once CompareOfFloatsByEqualityOperator
             var m = (p2.Y - p1.Y) / (deltaX == 0 ? double.MinValue : deltaX);
-            return m * (value - p1.X) + p1.Y;
+            var d = m*(value - p1.X) + p1.Y;
+
+            return d;
         }
 
         internal CoreSize PrepareChart(AxisTags source, ChartCore chart)

--- a/Core/ChartUpdater.cs
+++ b/Core/ChartUpdater.cs
@@ -28,10 +28,7 @@ namespace LiveCharts
 {
     public class ChartUpdater : IChartUpdater
     {
-        public event Action FrecuencyUpdate;
-
         public ChartCore Chart { get; set; }
-        public TimeSpan Frequency { get; set; }
         public bool IsUpdating { get; set; }
         public bool RestartViewRequested { get; set; }
 
@@ -44,6 +41,11 @@ namespace LiveCharts
         }
 
         public virtual void Run(bool restartView = false)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual void UpdateFrequency(TimeSpan freq)
         {
             throw new NotImplementedException();
         }
@@ -79,36 +81,6 @@ namespace LiveCharts
             Chart.View.CountElements();
 #endif
         }
-
-        public void Cancel()
-        {
-#if DEBUG
-            Debug.WriteLine("Chart update cancelation requested!");
-#endif
-        }
-
-        public void UpdateFrequency()
-        {
-            if (Chart == null) return;
-
-            if (Chart.View.UpdaterFrequency == null)
-            {
-                //by defualt the chart will update according to animations speed
-                //if you need to force the update in a shorter interval then use the 
-                //Chart.UpdateFrequency property
-
-                var ms = Chart.View.DisableAnimations ? 0 : Chart.View.AnimationsSpeed.TotalMilliseconds;
-
-                if (ms < 100) ms = 100;
-
-                Frequency = TimeSpan.FromMilliseconds(ms);
-
-                return;
-            }
-
-            Frequency = Chart.View.UpdaterFrequency.Value;
-
-            if (FrecuencyUpdate != null) FrecuencyUpdate.Invoke();
-        }
+       
     }
 }

--- a/Core/ChartValues.cs
+++ b/Core/ChartValues.cs
@@ -20,6 +20,7 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using LiveCharts.Charts;
@@ -74,12 +75,12 @@ namespace LiveCharts
             var config = GetConfig();
             if (config == null) return;
 
-            var xMin = double.MaxValue;
-            var xMax = double.MinValue;
-            var yMin = double.MaxValue;
-            var yMax = double.MinValue;
-            var wMin = double.MaxValue;
-            var wMax = double.MinValue;
+            var xMin = double.PositiveInfinity;
+            var xMax = double.NegativeInfinity;
+            var yMin = double.PositiveInfinity;
+            var yMax = double.NegativeInfinity;
+            var wMin = double.PositiveInfinity;
+            var wMax = double.NegativeInfinity;
             
             foreach (var xyw in IndexData().Select(data => config.GetEvaluation(data)))
             {
@@ -93,9 +94,9 @@ namespace LiveCharts
                 if (xyw[1].W > wMax) wMax = xyw[1].W;
             }
 
-            XLimit = new CoreLimit(xMin, xMax);
-            YLimit = new CoreLimit(yMin, yMax);
-            WeigthLimit = new CoreLimit(wMin, wMax);
+            XLimit = new CoreLimit(double.IsInfinity(xMin) ? 0 : xMin, double.IsInfinity(yMin) ? 1 : xMax);
+            YLimit = new CoreLimit(double.IsInfinity(yMin) ? 0 : yMin, double.IsInfinity(yMax) ? 1 : yMax);
+            WeigthLimit = new CoreLimit(double.IsInfinity(wMin) ? 0 : wMin, double.IsInfinity(wMax) ? 1 : wMax);
         }
 
         public void InitializeGarbageCollector()

--- a/Core/Charts/CartesianChartCore.cs
+++ b/Core/Charts/CartesianChartCore.cs
@@ -33,7 +33,6 @@ namespace LiveCharts.Charts
         public CartesianChartCore(IChartView view, IChartUpdater updater) : base(view, updater)
         {
             updater.Chart = this;
-            updater.UpdateFrequency();
         }
 
         #endregion
@@ -61,6 +60,12 @@ namespace LiveCharts.Charts
                 xi.MaxLimit = xi.MaxValue ?? cartesianSeries.Where(x => x.View.ScalesXAt == index)
                     .Select(x => x.GetMaxX(xi))
                     .DefaultIfEmpty(0).Max();
+
+                if (Math.Abs(xi.MinLimit - xi.MaxLimit) < xi.S*.01)
+                {
+                    xi.MinLimit -= xi.S;
+                    xi.MaxLimit += xi.S;
+                }
             }
 
             for (var index = 0; index < AxisY.Count; index++)
@@ -73,6 +78,12 @@ namespace LiveCharts.Charts
                 yi.MaxLimit = yi.MaxValue ?? cartesianSeries.Where(x => x.View.ScalesYAt == index)
                     .Select(x => x.GetMaxY(yi))
                     .DefaultIfEmpty(0).Max();
+
+                if (Math.Abs(yi.MinLimit - yi.MaxLimit) < yi.S * .01)
+                {
+                    yi.MinLimit -= yi.S;
+                    yi.MaxLimit += yi.S;
+                }
             }
 
             PrepareUnitWidthColumns();

--- a/Core/Definitions.cs
+++ b/Core/Definitions.cs
@@ -259,8 +259,7 @@ namespace LiveCharts
     {
         ChartCore Chart { get; set; }
         void Run(bool restartView = false);
-        void Cancel();
-        void UpdateFrequency();
+        void UpdateFrequency(TimeSpan freq);
     }
 
     public interface IObservableChartPoint
@@ -376,7 +375,6 @@ namespace LiveCharts
 
         SeriesCollection Series { get; set; }
         TimeSpan TooltipTimeout { get; set; }
-        TimeSpan? UpdaterFrequency { get; set; }
         ZoomingOptions Zoom { get; set; }
         LegendLocation LegendLocation { get; set; }
         bool DisableAnimations { get; set; }

--- a/Examples/Wpf/CartesianChart/ConstantChangesChart.xaml
+++ b/Examples/Wpf/CartesianChart/ConstantChangesChart.xaml
@@ -1,0 +1,27 @@
+﻿<UserControl x:Class="Wpf.CartesianChart.ConstantChangesChart"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Wpf.CartesianChart"
+             xmlns:lc="clr-namespace:LiveCharts.Wpf;assembly=LiveCharts.Wpf"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance local:ConstantChangesChart}">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="*"></RowDefinition>
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0" TextWrapping="Wrap">
+            <Bold>New in 0.7.0</Bold> High frequency charts updates, just one thing, the chart update frequency is directly releated
+            with the animations speed property, if you need to update the chart fast then reduce the animations speed property to 50-10ms 
+            animations run really well at fast speeds, you can also disable animations, but come on, animations is one of the best things in this library!
+        </TextBlock>
+        <Button Grid.Row="1" Height="30" Click="RunDataOnClick">
+            Inject/Stop Data
+        </Button>
+        <!--Notice the animations speed property is at 50 miliseconds.-->
+        <lc:CartesianChart Grid.Row="2" Series="{Binding SeriesCollection}" AnimationsSpeed="0:0:0.05"></lc:CartesianChart>
+    </Grid>
+</UserControl>

--- a/Examples/Wpf/CartesianChart/ConstantChangesChart.xaml.cs
+++ b/Examples/Wpf/CartesianChart/ConstantChangesChart.xaml.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Threading;
+using LiveCharts;
+using LiveCharts.Defaults;
+using LiveCharts.Wpf;
+
+namespace Wpf.CartesianChart
+{
+    /// <summary>
+    /// Interaction logic for ConstantChangesChart.xaml
+    /// </summary>
+    public partial class ConstantChangesChart
+    {
+        public ConstantChangesChart()
+        {
+            InitializeComponent();
+
+            Buffer = new ChartValues<ObservableValue>();
+
+            SeriesCollection = new SeriesCollection
+            {
+                new LineSeries {Values = Buffer, StrokeThickness = 4, PointDiameter = 0}
+            };
+
+            Timer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(50)
+            };
+
+            Timer.Tick += TimerOnTick;
+
+            IsDataInjectionRunning = false;
+
+            R = new Random();
+
+            DataContext = this;
+        }
+
+        public SeriesCollection SeriesCollection { get; set; }
+        public ChartValues<ObservableValue> Buffer { get; set; }
+        public DispatcherTimer Timer { get; set; }
+        public bool IsDataInjectionRunning { get; set; }
+        public Random R { get; set; }
+
+        private void RunDataOnClick(object sender, RoutedEventArgs e)
+        {
+            if (IsDataInjectionRunning)
+            {
+                Timer.Stop();
+                IsDataInjectionRunning = false;
+            }
+            else
+            {
+                Timer.Start();
+                IsDataInjectionRunning = true;
+            }
+        }
+
+        private void TimerOnTick(object sender, EventArgs eventArgs)
+        {
+            Buffer.Add(new ObservableValue(R.Next(0, 10)));
+            if (Buffer.Count > 50) Buffer.RemoveAt(0);
+        }
+    }
+}

--- a/Examples/Wpf/MainWindow.xaml.cs
+++ b/Examples/Wpf/MainWindow.xaml.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Navigation;
-using LiveCharts.Wpf;
 using Wpf.Annotations;
 using Wpf.CartesianChart;
 
@@ -24,18 +23,19 @@ namespace Wpf
 
             CartesianExamples = new List<UserControl>
             {
-                new Welcome(),
-                new ResponsiveExample(),
-                new CustomTypesPlotting(),
-                new LineExample(),
-                new BarExample(),
-                new BubblesExample(),
-                new StackedAreaExample(),
-                new FinancialExample(),
-                new StackedBarExample(),
-                new SectionsExample(),
-                new ZoomingAndPanning(),
-                new MixingTypes()
+                //new Welcome(),
+                //new ResponsiveExample(),
+                //new CustomTypesPlotting(),
+                //new LineExample(),
+                //new BarExample(),
+                //new BubblesExample(),
+                //new StackedAreaExample(),
+                //new FinancialExample(),
+                //new StackedBarExample(),
+                //new SectionsExample(),
+                //new ZoomingAndPanning(),
+                new ConstantChangesChart(),
+                //new MixingTypes()
             };
 
             CartesianView = CartesianExamples != null && CartesianExamples.Count > 0 ? CartesianExamples[0] : null;

--- a/Examples/Wpf/MainWindow.xaml.cs
+++ b/Examples/Wpf/MainWindow.xaml.cs
@@ -23,19 +23,19 @@ namespace Wpf
 
             CartesianExamples = new List<UserControl>
             {
-                //new Welcome(),
-                //new ResponsiveExample(),
-                //new CustomTypesPlotting(),
-                //new LineExample(),
-                //new BarExample(),
-                //new BubblesExample(),
-                //new StackedAreaExample(),
-                //new FinancialExample(),
-                //new StackedBarExample(),
-                //new SectionsExample(),
-                //new ZoomingAndPanning(),
+                new Welcome(),
+                new ResponsiveExample(),
+                new CustomTypesPlotting(),
+                new LineExample(),
+                new BarExample(),
+                new BubblesExample(),
+                new StackedAreaExample(),
+                new FinancialExample(),
+                new StackedBarExample(),
+                new SectionsExample(),
+                new ZoomingAndPanning(),
                 new ConstantChangesChart(),
-                //new MixingTypes()
+                new MixingTypes()
             };
 
             CartesianView = CartesianExamples != null && CartesianExamples.Count > 0 ? CartesianExamples[0] : null;

--- a/Examples/Wpf/Wpf.csproj
+++ b/Examples/Wpf/Wpf.csproj
@@ -66,6 +66,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="CartesianChart\ConstantChangesChart.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="CartesianChart\FinancialExample.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -119,6 +123,9 @@
     </Compile>
     <Compile Include="CartesianChart\BubblesExample.xaml.cs">
       <DependentUpon>BubblesExample.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="CartesianChart\ConstantChangesChart.xaml.cs">
+      <DependentUpon>ConstantChangesChart.xaml</DependentUpon>
     </Compile>
     <Compile Include="CartesianChart\FinancialExample.xaml.cs">
       <DependentUpon>FinancialExample.xaml</DependentUpon>

--- a/WpfView/CartesianChart.cs
+++ b/WpfView/CartesianChart.cs
@@ -20,8 +20,8 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
+using System;
 using LiveCharts.Charts;
-using LiveCharts.Wpf.Components;
 using LiveCharts.Wpf.Components.Chart;
 
 namespace LiveCharts.Wpf
@@ -30,7 +30,8 @@ namespace LiveCharts.Wpf
     {
         public CartesianChart()
         {
-            var updater = new Components.ChartUpdater();
+            var freq = DisableAnimations ? TimeSpan.FromMilliseconds(10) : AnimationsSpeed;
+            var updater = new Components.ChartUpdater(freq);
             ChartCoreModel = new CartesianChartCore(this, updater);
         }
     }

--- a/WpfView/Components/Chart/Chart.ZoomPan.cs
+++ b/WpfView/Components/Chart/Chart.ZoomPan.cs
@@ -33,7 +33,7 @@ namespace LiveCharts.Wpf.Components.Chart
 
         private void MouseWheelOnRoll(object sender, MouseWheelEventArgs e)
         {
-            if (Model.PivotZoomingAxis == AxisTags.None) return;
+            if (Zoom == ZoomingOptions.None) return;
 
             var p = e.GetPosition(this);
 
@@ -53,7 +53,6 @@ namespace LiveCharts.Wpf.Components.Chart
             DragOrigin = new Point(
                 ChartFunctions.FromDrawMargin(DragOrigin.X, AxisTags.X, Model),
                 ChartFunctions.FromDrawMargin(DragOrigin.Y, AxisTags.Y, Model));
-            Debug.WriteLine("drag started at " + DragOrigin.X + ", " + DragOrigin.Y);
         }
 
         private void OnDraggingEnd(object sender, MouseButtonEventArgs e)

--- a/WpfView/Components/Chart/Chart.cs
+++ b/WpfView/Components/Chart/Chart.cs
@@ -110,6 +110,19 @@ namespace LiveCharts.Wpf.Components.Chart
             };
         }
 
+        private static void UpdateChartFrequency(DependencyObject o, DependencyPropertyChangedEventArgs e)
+        {
+            var wpfChart = (Chart) o;
+
+            var freq = wpfChart.DisableAnimations ? TimeSpan.FromMilliseconds(10) : wpfChart.AnimationsSpeed;
+
+            if (wpfChart.Model == null || wpfChart.Model.Updater == null) return;
+
+            wpfChart.Model.Updater.UpdateFrequency(freq);
+
+            CallChartUpdater(true)(o, e);
+        }
+
         #endregion
 
         #region Obsoletes, this properties will dissapear in future versions

--- a/WpfView/Components/Chart/Chart.properties.cs
+++ b/WpfView/Components/Chart/Chart.properties.cs
@@ -115,50 +115,13 @@ namespace LiveCharts.Wpf.Components.Chart
         public SeriesCollection Series
         {
             get { return (SeriesCollection)GetValue(SeriesProperty); }
-            set
-            {
-#if DEBUG
-                if (DesignerProperties.GetIsInDesignMode(this))
-                {
-                    if (value == null || value.Count == 0)
-                    {
-                        var r = new Random();
-                        SetValue(SeriesProperty,
-                            new SeriesCollection
-                            {
-                                new LineSeries
-                                {
-                                    Values = new ChartValues<double>
-                                        {
-                                            r.NextDouble()*10,
-                                            r.NextDouble()*10,
-                                            r.NextDouble()*10,
-                                            r.NextDouble()*10,
-                                            r.NextDouble()*10
-                                        }
-                                }
-                            });
-                        return;
-                    }
-                    return;
-                }
-#endif
-                SetValue(SeriesProperty, value);
-            }
-        }
-
-        public static readonly DependencyProperty UpdaterFrequencyProperty = DependencyProperty.Register(
-            "UpdaterFrequency", typeof(TimeSpan?), typeof(Chart), new PropertyMetadata(default(TimeSpan?)));
-
-        public TimeSpan? UpdaterFrequency
-        {
-            get { return (TimeSpan?)GetValue(UpdaterFrequencyProperty); }
-            set { SetValue(UpdaterFrequencyProperty, value); }
+            set { SetValue(SeriesProperty, value);}
         }
 
         public static readonly DependencyProperty AnimationsSpeedProperty = DependencyProperty.Register(
             "AnimationsSpeed", typeof(TimeSpan), typeof(Chart),
-            new PropertyMetadata(default(TimeSpan), CallChartUpdater(true)));
+            new PropertyMetadata(default(TimeSpan), UpdateChartFrequency));
+
         /// <summary>
         /// Gets or sets the default animation speed for this chart, you can override this speed for each element (series and axes)
         /// </summary>
@@ -169,8 +132,8 @@ namespace LiveCharts.Wpf.Components.Chart
         }
 
         public static readonly DependencyProperty DisableAnimationsProperty = DependencyProperty.Register(
-            "DisableAnimations", typeof(bool), typeof(Chart),
-            new PropertyMetadata(default(bool), CallChartUpdater(true)));
+            "DisableAnimations", typeof (bool), typeof (Chart),
+            new PropertyMetadata(default(bool), UpdateChartFrequency));
         /// <summary>
         /// Gets or sets if the chart is animated or not.
         /// </summary>

--- a/WpfView/Components/ChartUpdater.cs
+++ b/WpfView/Components/ChartUpdater.cs
@@ -1,17 +1,15 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Windows.Threading;
 
 namespace LiveCharts.Wpf.Components
 {
     public class ChartUpdater : LiveCharts.ChartUpdater
     {
-        public ChartUpdater()
+        public ChartUpdater(TimeSpan frequency)
         {
-            Timer = new DispatcherTimer {Interval = TimeSpan.FromMilliseconds(50)};
-            FrecuencyUpdate += () =>
-            {
-                Timer.Interval = Frequency;
-            };
+            Timer = new DispatcherTimer {Interval = frequency};
+
             Timer.Tick += (sender, args) =>
             {
                 Update();
@@ -28,6 +26,11 @@ namespace LiveCharts.Wpf.Components
 
             IsUpdating = true;
             Timer.Start();
+        }
+
+        public override void UpdateFrequency(TimeSpan freq)
+        {
+            Timer.Interval = freq;
         }
     }
 }


### PR DESCRIPTION
Bye to portable branch! livecharts has now a portable design, soon will be extended to Uwp and Xamarin

Also Fixed high frequency charts, now the charts are directly related with the animationsSpeed property, reduce the animations speed to increase the update rate, you can also disable animations but come on do not disable them, they are beautiful, reduce them to 10ms or something, they run really fast.