### PR TITLE
Include LiveCharts as dependency in Nuget build

### DIFF
--- a/WinFormsView/WinFormsView.nuspec
+++ b/WinFormsView/WinFormsView.nuspec
@@ -14,6 +14,9 @@
     <releaseNotes>See https://github.com/beto-rodriguez/Live-Charts/releases</releaseNotes>
     <copyright>Copyright 2016</copyright>
     <tags>Chart Charting Plot Plotting WinForms</tags> 
+	<dependencies>
+      <dependency id="LiveCharts" version="0.0.0.0" />
+    </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="PresentationFramework" targetFramework="net403" />
       <frameworkAssembly assemblyName="PresentationCore" targetFramework="net403"/>

--- a/WpfView/WpfView.nuspec
+++ b/WpfView/WpfView.nuspec
@@ -14,6 +14,9 @@
     <releaseNotes>See https://github.com/beto-rodriguez/Live-Charts/releases</releaseNotes>
     <copyright>Copyright 2016</copyright>
     <tags>Chart Charting Plot Plotting Wpf WindowsPresentationFoundation</tags>
+	<dependencies>
+      <dependency id="LiveCharts" version="0.0.0.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="bin\net403\LiveCharts.Wpf.dll" target="lib\net403" />


### PR DESCRIPTION
Added LiveCharts as a dependency in the nuspec files for Winforms and WPF build.
It seems like the -IncludeReferencedProjects will only work when used with a .csproj file and not with a .nuspec file so I just added the dependency in the nuspec directly.