### PR TITLE
ScatterPointView: correctly set the shape position

### DIFF
--- a/WpfView/Points/ScatterPointView.cs
+++ b/WpfView/Points/ScatterPointView.cs
@@ -66,8 +66,8 @@ namespace LiveCharts.Wpf.Points
                 Shape.Width = Diameter;
                 Shape.Height = Diameter;
 
-                Canvas.SetTop(Shape, current.ChartLocation.Y - Shape.Width*.5);
-                Canvas.SetLeft(Shape, current.ChartLocation.X - Shape.Height*.5);
+                Canvas.SetTop(Shape, current.ChartLocation.Y - Shape.Height*.5);
+                Canvas.SetLeft(Shape, current.ChartLocation.X - Shape.Width*.5);
 
                 if (DataLabel != null)
                 {


### PR DESCRIPTION
This is small modification with no actual effect since Width = Height = Diameter, but the inversion could trigger a bug later if the initializtion of Shape.Width/Height change