### PR TITLE
Correct the implementation of int Add(object value) - resolves #322

### DIFF
--- a/Core/Helpers/NoisyCollection.cs
+++ b/Core/Helpers/NoisyCollection.cs
@@ -178,7 +178,7 @@ namespace LiveCharts.Helpers
         {
             _source.Add((T)value);
             OnCollectionChanged(null, new[] {(T) value});
-            return _source.Count;
+            return _source.IndexOf((T)value);
         }
 
         /// <summary>


### PR DESCRIPTION
As per the issue referenced. Simply corrects the return value of int Add(object value) so that it matches the specification of IList

resolves #322