### PR TITLE
Use Source.Count as the iteration limit as it is the copy just made t…

### DIFF
--- a/Core/ChartValues.cs
+++ b/Core/ChartValues.cs
@@ -154,7 +154,7 @@ namespace LiveCharts
 
             var source = this.ToList(); //copy it, to prevent async issues
 
-            for (var index = 0; index < Count; index++)
+            for (var index = 0; index < source.Count; index++)
             {
                 var value = source[index];
                 if (isObservable)


### PR DESCRIPTION
Came across an issue when running under heavy load and updating frequently (and keeping a fixed number of points in the chart) 

Line 155 copies the list "to prevent async issues" then the following for loop uses the original Count as the limiter. Count can and has been observed to change during the for loop when adding or removing from the list so the length of source and this.Count can be different causing an exception.

