### PR TITLE
Initializes a new instance of chart values, with a given collection.

### DIFF
--- a/Core/ChartValues.cs
+++ b/Core/ChartValues.cs
@@ -47,6 +47,15 @@ namespace LiveCharts
             NoisyCollectionChanged += OnChanged;
         }
 
+        /// <summary>
+        /// Initializes a new instance of chart values, with a given collection
+        /// </summary>
+        public ChartValues(IEnumerable<T> collection) : base(collection)
+        {
+            Trackers = new Dictionary<ISeriesView, PointTracker>();
+            NoisyCollectionChanged += OnChanged;
+        }
+
         #endregion
 
         #region Properties


### PR DESCRIPTION
#### Summary

Enables it that users don't have to convert an existing IENumberable to a ChartValue, it accepts a IENumberable in the constructor. It might be more obvious to use it this way. It doesn't need the `using LiveCharts.Helpers` reference either.

Example:

Was:

```
double[] _values = new double[]{10, 20, 30, 40};

SeriesCollection = new SeriesCollection
            {
                new ColumnSeries
                {
                    Title = "Example",
                    Values = _values.AsChartValues();
                }
            };
```

Becomes:
```
double[] _values = new double[]{10, 20, 30, 40};

SeriesCollection = new SeriesCollection
            {
                new ColumnSeries
                {
                    Title = "Example",
                    Values = new ChartValues<double>(_values)
                }
            };
```

#### Solves 

-

