### PR TITLE
Set default font for Series to Segoe UI, #363

### DIFF
--- a/WpfView/Series.cs
+++ b/WpfView/Series.cs
@@ -177,7 +177,7 @@ namespace LiveCharts.Wpf
 
         public static readonly DependencyProperty FontFamilyProperty = DependencyProperty.Register(
             "FontFamily", typeof (FontFamily), typeof (Series), 
-            new PropertyMetadata(default(FontFamily)));
+            new PropertyMetadata(new FontFamily("Segoe UI")));
         /// <summary>
         /// Gets or sets labels font family
         /// </summary>


### PR DESCRIPTION
#### Summary

Set default font for Series to Segoe UI to avoid binding error.


#### Solves 

Fixes #363

