### PR TITLE
Develop

### DIFF
--- a/Core/Definitions/Series/ILineSeriesView.cs
+++ b/Core/Definitions/Series/ILineSeriesView.cs
@@ -27,6 +27,7 @@ namespace LiveCharts.Definitions.Series
     public interface ILineSeriesView : ISeriesView
     {
         double LineSmoothness { get; set; }
+        double AreaLimit { get; set; }
         void StartSegment(int atIndex, CorePoint location);
         void EndSegment(int atIndex, CorePoint location);
     }

--- a/Core/SeriesAlgorithms/LineAlgorithm.cs
+++ b/Core/SeriesAlgorithms/LineAlgorithm.cs
@@ -91,6 +91,7 @@ namespace LiveCharts.SeriesAlgorithms
                 segmentPosition += segmentPosition == 0 ? 1 : 2;
 
                 ChartPoint previousDrawn = null;
+                var isOpen = false;
 
                 for (var index = 0; index < segment.Count; index++)
                 {
@@ -164,8 +165,10 @@ namespace LiveCharts.SeriesAlgorithms
                     {
                         p3 = new CorePoint(p3.X + uw.X, p3.Y - uw.Y);
                     }
+
+                    isOpen = true;
                 }
-                lineView.EndSegment(segmentPosition, p1);
+                if (isOpen) lineView.EndSegment(segmentPosition, p1);
                 segmentPosition++;
             }
         }

--- a/Core/SeriesAlgorithms/LineAlgorithm.cs
+++ b/Core/SeriesAlgorithms/LineAlgorithm.cs
@@ -44,8 +44,7 @@ namespace LiveCharts.SeriesAlgorithms
 
             var segmentPosition = 0;
 
-            var lineView = View as ILineSeriesView;
-            if (lineView == null) return;
+            var lineView = (ILineSeriesView) View;
 
             var smoothness = lineView.LineSmoothness;
             smoothness = smoothness > 1 ? 1 : (smoothness < 0 ? 0 : smoothness);

--- a/Examples/Wpf/CartesianChart/Missing Line Points/MissingPointsExample.xaml
+++ b/Examples/Wpf/CartesianChart/Missing Line Points/MissingPointsExample.xaml
@@ -7,6 +7,10 @@
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>
-        <lvc:CartesianChart Series="{Binding Series}"></lvc:CartesianChart> 
+        <lvc:CartesianChart Series="{Binding Series}">
+            <lvc:CartesianChart.AxisX>
+                <lvc:Axis MinValue="5.2"></lvc:Axis>
+            </lvc:CartesianChart.AxisX>
+        </lvc:CartesianChart> 
     </Grid>
 </UserControl>

--- a/Examples/Wpf/CartesianChart/MixingSeries/MixingSeries.xaml
+++ b/Examples/Wpf/CartesianChart/MixingSeries/MixingSeries.xaml
@@ -1,12 +1,13 @@
-﻿<UserControl x:Class="Wpf.CartesianChart.MixingTypes"
+﻿<UserControl x:Class="Wpf.CartesianChart.MixingSeries.MixingTypes"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Wpf.CartesianChart"
              xmlns:lvc="clr-namespace:LiveCharts.Wpf;assembly=LiveCharts.Wpf"
+             xmlns:mixingSeries="clr-namespace:Wpf.CartesianChart.MixingSeries"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance local:MixingTypes}">
+             d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance mixingSeries:MixingTypes}">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>

--- a/Examples/Wpf/CartesianChart/MixingSeries/MixingSeries.xaml.cs
+++ b/Examples/Wpf/CartesianChart/MixingSeries/MixingSeries.xaml.cs
@@ -29,7 +29,8 @@ namespace Wpf.CartesianChart.MixingSeries
                     new ObservableValue(2),
                     new ObservableValue(3)
                 },
-                PointForeround = new SolidColorBrush(Color.FromRgb(50,50,50))
+                PointForeround = new SolidColorBrush(Color.FromRgb(50,50,50)),
+                AreaLimit = 0
             };
 
             ScatterSeries = new ScatterSeries

--- a/Examples/Wpf/CartesianChart/MixingSeries/MixingSeries.xaml.cs
+++ b/Examples/Wpf/CartesianChart/MixingSeries/MixingSeries.xaml.cs
@@ -27,7 +27,7 @@ namespace Wpf.CartesianChart.MixingSeries
                     new ObservableValue(5),
                     new ObservableValue(7),
                     new ObservableValue(2),
-                    new ObservableValue(3),
+                    new ObservableValue(3)
                 },
                 PointForeround = new SolidColorBrush(Color.FromRgb(50,50,50))
             };
@@ -50,7 +50,7 @@ namespace Wpf.CartesianChart.MixingSeries
                     new ObservableValue(5),
                     new ObservableValue(7),
                     new ObservableValue(2),
-                    new ObservableValue(3),
+                    new ObservableValue(3)
                 }
             };
 
@@ -64,7 +64,7 @@ namespace Wpf.CartesianChart.MixingSeries
             DataContext = this;
         }
 
-        public LiveCharts.Wpf.ScatterSeries ScatterSeries { get; set; }
+        public ScatterSeries ScatterSeries { get; set; }
         public LineSeries LineSeries { get; set; }
         public ColumnSeries ColumnSeries { get; set; }
         public SeriesCollection SeriesCollection { get; set; }

--- a/Examples/Wpf/CartesianChart/MixingSeries/MixingSeries.xaml.cs
+++ b/Examples/Wpf/CartesianChart/MixingSeries/MixingSeries.xaml.cs
@@ -1,23 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
-using System.Windows.Shapes;
 using LiveCharts;
 using LiveCharts.Defaults;
 using LiveCharts.Wpf;
 
-namespace Wpf.CartesianChart
+namespace Wpf.CartesianChart.MixingSeries
 {
     /// <summary>
     /// Interaction logic for MixingSeries.xaml
@@ -37,7 +29,7 @@ namespace Wpf.CartesianChart
                     new ObservableValue(2),
                     new ObservableValue(3),
                 },
-                Fill = Brushes.Transparent
+                PointForeround = new SolidColorBrush(Color.FromRgb(50,50,50))
             };
 
             ScatterSeries = new ScatterSeries

--- a/Examples/Wpf/MainWindow.xaml.cs
+++ b/Examples/Wpf/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ using Wpf.CartesianChart.Linq;
 using Wpf.CartesianChart.LogarithmScale;
 using Wpf.CartesianChart.ManualZAndP;
 using Wpf.CartesianChart.Missing_Line_Points;
+using Wpf.CartesianChart.MixingSeries;
 using Wpf.CartesianChart.NegativeStackedRow;
 using Wpf.CartesianChart.PointShapeLine;
 using Wpf.CartesianChart.PointState;

--- a/WpfView/CandleSeries.cs
+++ b/WpfView/CandleSeries.cs
@@ -202,15 +202,15 @@ namespace LiveCharts.Wpf
 
         private void InitializeDefuaults()
         {
-            SetValue(StrokeThicknessProperty, 1d);
-            SetValue(MaxColumnWidthProperty, 35d);
+            SetCurrentValue(StrokeThicknessProperty, 1d);
+            SetCurrentValue(MaxColumnWidthProperty, 35d);
             SetValue(MaxWidthProperty, 25d);
-            SetValue(IncreaseBrushProperty, new SolidColorBrush(Color.FromRgb(254, 178, 0)));
-            SetValue(DecreaseBrushProperty, new SolidColorBrush(Color.FromRgb(238, 83, 80)));
+            SetCurrentValue(IncreaseBrushProperty, new SolidColorBrush(Color.FromRgb(254, 178, 0)));
+            SetCurrentValue(DecreaseBrushProperty, new SolidColorBrush(Color.FromRgb(238, 83, 80)));
 
             Func<ChartPoint, string> defaultLabel = x =>
                 string.Format("O: {0}, H: {1}, L: {2} C: {3}", x.Open, x.High, x.Low, x.Close);
-            SetValue(LabelPointProperty, defaultLabel);
+            SetCurrentValue(LabelPointProperty, defaultLabel);
 
             DefaultFillOpacity = 1;
         }

--- a/WpfView/LineSeries.cs
+++ b/WpfView/LineSeries.cs
@@ -371,7 +371,6 @@ namespace LiveCharts.Wpf
             var uw = ChartFunctions.GetUnitWidth(AxisOrientation.X, Model.Chart, ScalesXAt);
             location.X -= uw/2;
 
-
             if (splitter.IsNew)
             {
                 splitter.Right.Point = new Point(location.X, Model.Chart.DrawMargin.Height);

--- a/WpfView/LineSeries.cs
+++ b/WpfView/LineSeries.cs
@@ -156,11 +156,10 @@ namespace LiveCharts.Wpf
                 xi += uw;
                 
                 if (Model.Chart.View.DisableAnimations)
-                    Figure.StartPoint = new Point(xi, Model.Chart.DrawMargin.Height);
+                    Figure.StartPoint = new Point(xi, areaLimit);
                 else
                     Figure.BeginAnimation(PathFigure.StartPointProperty,
-                        new PointAnimation(new Point(xi, areaLimit),
-                            Model.Chart.View.AnimationsSpeed));
+                        new PointAnimation(new Point(xi, areaLimit), Model.Chart.View.AnimationsSpeed));
             }
 
             if (IsPathInitialized)

--- a/WpfView/LineSeries.cs
+++ b/WpfView/LineSeries.cs
@@ -131,15 +131,20 @@ namespace LiveCharts.Wpf
 
             SplittersCollector++;
 
+            var uw = ChartFunctions.GetUnitWidth(AxisOrientation.X, Model.Chart, ScalesXAt);
+            var zero = ChartFunctions.ToDrawMargin(0, AxisOrientation.Y, Model.Chart, ScalesYAt);
+
             if (Figure != null && Values != null)
             {
-                var xIni = ChartFunctions.ToDrawMargin(ActualValues.GetTracker(this).XLimit.Min, AxisOrientation.X, Model.Chart, ScalesXAt);
+                var xi = (ActualValues.GetPoints(this).FirstOrDefault() ?? new ChartPoint()).X;
+                xi = ChartFunctions.ToDrawMargin(xi, AxisOrientation.X, Model.Chart, ScalesXAt);
+                xi += uw / 2;
 
                 if (Model.Chart.View.DisableAnimations)
-                    Figure.StartPoint = new Point(xIni, Model.Chart.DrawMargin.Height);
+                    Figure.StartPoint = new Point(xi, Model.Chart.DrawMargin.Height);
                 else
                     Figure.BeginAnimation(PathFigure.StartPointProperty,
-                        new PointAnimation(new Point(xIni, Model.Chart.DrawMargin.Height),
+                        new PointAnimation(new Point(xi, zero /*Model.Chart.DrawMargin.Height*/),
                             Model.Chart.View.AnimationsSpeed));
             }
 
@@ -175,8 +180,10 @@ namespace LiveCharts.Wpf
             
             Model.Chart.View.EnsureElementBelongsToCurrentDrawMargin(Path);
 
-            var x = ChartFunctions.ToDrawMargin(ActualValues.GetTracker(this).XLimit.Min, AxisOrientation.X, Model.Chart, ScalesXAt);
-            Figure.StartPoint = new Point(x, Model.Chart.DrawMargin.Height);
+            var x = (ActualValues.GetPoints(this).FirstOrDefault() ?? new ChartPoint()).X;
+            x = ChartFunctions.ToDrawMargin(x, AxisOrientation.X, Model.Chart, ScalesXAt);
+            x += uw/2;
+            Figure.StartPoint = new Point(x, zero /*Model.Chart.DrawMargin.Height*/);
         }
 
         public override IChartPointView GetPointView(IChartPointView view, ChartPoint point, string label)
@@ -360,6 +367,11 @@ namespace LiveCharts.Wpf
             var animSpeed = Model.Chart.View.AnimationsSpeed;
             var noAnim = Model.Chart.View.DisableAnimations;
 
+            var zero = ChartFunctions.ToDrawMargin(0, AxisOrientation.Y, Model.Chart, ScalesYAt);
+            var uw = ChartFunctions.GetUnitWidth(AxisOrientation.X, Model.Chart, ScalesXAt);
+            location.X -= uw/2;
+
+
             if (splitter.IsNew)
             {
                 splitter.Right.Point = new Point(location.X, Model.Chart.DrawMargin.Height);
@@ -367,10 +379,10 @@ namespace LiveCharts.Wpf
 
             Figure.Segments.Remove(splitter.Right);
             if (noAnim)
-                splitter.Right.Point = new Point(location.X, Model.Chart.DrawMargin.Height);
+                splitter.Right.Point = new Point(location.X, zero /*Model.Chart.DrawMargin.Height*/);
             else
                 splitter.Right.BeginAnimation(LineSegment.PointProperty,
-                    new PointAnimation(new Point(location.X, Model.Chart.DrawMargin.Height), animSpeed));
+                    new PointAnimation(new Point(location.X, zero /*Model.Chart.DrawMargin.Height*/), animSpeed));
             Figure.Segments.Insert(atIndex, splitter.Right);
 
             splitter.IsNew = false;

--- a/WpfView/RowSeries.cs
+++ b/WpfView/RowSeries.cs
@@ -90,16 +90,16 @@ namespace LiveCharts.Wpf
             set { SetValue(RowPaddingProperty, value); }
         }
 
-        public static readonly DependencyProperty LabelPositionProperty = DependencyProperty.Register(
-            "LabelPosition", typeof(BarLabelPosition), typeof(RowSeries), 
+        public static readonly DependencyProperty LabelsPositionProperty = DependencyProperty.Register(
+            "LabelsPosition", typeof(BarLabelPosition), typeof(RowSeries), 
             new PropertyMetadata(default(BarLabelPosition), CallChartUpdater()));
         /// <summary>
         /// Gets or sets where the label is placed
         /// </summary>
-        public BarLabelPosition LabelPosition
+        public BarLabelPosition LabelsPosition
         {
-            get { return (BarLabelPosition)GetValue(LabelPositionProperty); }
-            set { SetValue(LabelPositionProperty, value); }
+            get { return (BarLabelPosition)GetValue(LabelsPositionProperty); }
+            set { SetValue(LabelsPositionProperty, value); }
         }
 
 
@@ -171,7 +171,7 @@ namespace LiveCharts.Wpf
             if (point.Stroke != null) pbv.Rectangle.Stroke = (Brush) point.Stroke;
             if (point.Fill != null) pbv.Rectangle.Fill = (Brush) point.Fill;
 
-            pbv.LabelPosition = LabelPosition;
+            pbv.LabelPosition = LabelsPosition;
 
             return pbv;
         }
@@ -185,7 +185,7 @@ namespace LiveCharts.Wpf
             SetCurrentValue(StrokeThicknessProperty, 0d);
             SetCurrentValue(MaxRowHeigthProperty, 35d);
             SetCurrentValue(RowPaddingProperty, 2d);
-            SetCurrentValue(LabelPositionProperty, BarLabelPosition.Top);
+            SetCurrentValue(LabelsPositionProperty, BarLabelPosition.Top);
 
             Func<ChartPoint, string> defaultLabel = x => Model.CurrentXAxis.GetFormatter()(x.X);
             SetCurrentValue(LabelPointProperty, defaultLabel);

--- a/WpfView/VerticalLineSeries.cs
+++ b/WpfView/VerticalLineSeries.cs
@@ -78,16 +78,24 @@ namespace LiveCharts.Wpf
 
             SplittersCollector++;
 
+            var uw = Model.Chart.AxisY[ScalesYAt].EvaluatesUnitWidth
+                ? ChartFunctions.GetUnitWidth(AxisOrientation.Y, Model.Chart, ScalesYAt) / 2
+                : 0;
+            var areaLimit = 0d;
+            if (!double.IsNaN(AreaLimit))
+                areaLimit = ChartFunctions.ToDrawMargin(AreaLimit, AxisOrientation.Y, Model.Chart, ScalesYAt);
+
             if (Figure != null && Values != null)
             {
-                var yiIni = (ActualValues.GetPoints(this).FirstOrDefault() ?? new ChartPoint()).X;
-                var yIni = ChartFunctions.ToDrawMargin(yiIni, AxisOrientation.Y, Model.Chart, ScalesYAt);
+                var yi = (ActualValues.GetPoints(this).FirstOrDefault() ?? new ChartPoint()).Y;
+                yi = ChartFunctions.ToDrawMargin(yi, AxisOrientation.Y, Model.Chart, ScalesYAt);
+                yi -= uw;
 
                 if (Model.Chart.View.DisableAnimations)
-                    Figure.StartPoint = new Point(0, yIni);
+                    Figure.StartPoint = new Point(areaLimit, yi);
                 else
                     Figure.BeginAnimation(PathFigure.StartPointProperty,
-                        new PointAnimation(new Point(0, yIni),
+                        new PointAnimation(new Point(areaLimit, yi),
                             Model.Chart.View.AnimationsSpeed));
             }
 
@@ -122,9 +130,10 @@ namespace LiveCharts.Wpf
             Path.Data = geometry;
             Model.Chart.View.AddToDrawMargin(Path);
 
-            var yi = (ActualValues.GetPoints(this).FirstOrDefault() ?? new ChartPoint()).X;
-            var y = ChartFunctions.ToDrawMargin(yi, AxisOrientation.Y, Model.Chart, ScalesYAt);
-            Figure.StartPoint = new Point(0, y);
+            var y = (ActualValues.GetPoints(this).FirstOrDefault() ?? new ChartPoint()).Y;
+            y = ChartFunctions.ToDrawMargin(y, AxisOrientation.Y, Model.Chart, ScalesYAt);
+            y -= uw;
+            Figure.StartPoint = new Point(areaLimit, y);
         }
 
         public override IChartPointView GetPointView(IChartPointView view, ChartPoint point, string label)
@@ -286,12 +295,20 @@ namespace LiveCharts.Wpf
                 splitter.Right.Point = new Point(0, location.Y);
             }
 
+            var areaLimit = 0d;
+            if (!double.IsNaN(AreaLimit))
+                areaLimit = ChartFunctions.ToDrawMargin(AreaLimit, AxisOrientation.X, Model.Chart, ScalesXAt);
+            var uw = Model.Chart.AxisY[ScalesYAt].EvaluatesUnitWidth
+                ? ChartFunctions.GetUnitWidth(AxisOrientation.Y, Model.Chart, ScalesYAt) / 2
+                : 0;
+            location.Y += uw;
+
             Figure.Segments.Remove(splitter.Right);
             if (noAnim)
-                splitter.Right.Point = new Point(0, location.Y);
+                splitter.Right.Point = new Point(areaLimit, location.Y);
             else
                 splitter.Right.BeginAnimation(LineSegment.PointProperty,
-                    new PointAnimation(new Point(0, location.Y), animSpeed));
+                    new PointAnimation(new Point(areaLimit, location.Y), animSpeed));
             Figure.Segments.Insert(atIndex, splitter.Right);
 
             splitter.IsNew = false;

--- a/WpfView/VerticalLineSeries.cs
+++ b/WpfView/VerticalLineSeries.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -79,7 +80,8 @@ namespace LiveCharts.Wpf
 
             if (Figure != null && Values != null)
             {
-                var yIni = ChartFunctions.ToDrawMargin(Values.GetTracker(this).YLimit.Min, AxisOrientation.Y, Model.Chart, ScalesYAt);
+                var yiIni = (ActualValues.GetPoints(this).FirstOrDefault() ?? new ChartPoint()).X;
+                var yIni = ChartFunctions.ToDrawMargin(yiIni, AxisOrientation.Y, Model.Chart, ScalesYAt);
 
                 if (Model.Chart.View.DisableAnimations)
                     Figure.StartPoint = new Point(0, yIni);
@@ -120,7 +122,8 @@ namespace LiveCharts.Wpf
             Path.Data = geometry;
             Model.Chart.View.AddToDrawMargin(Path);
 
-            var y = ChartFunctions.ToDrawMargin(ActualValues.GetTracker(this).YLimit.Min, AxisOrientation.Y, Model.Chart, ScalesYAt);
+            var yi = (ActualValues.GetPoints(this).FirstOrDefault() ?? new ChartPoint()).X;
+            var y = ChartFunctions.ToDrawMargin(yi, AxisOrientation.Y, Model.Chart, ScalesYAt);
             Figure.StartPoint = new Point(0, y);
         }
 


### PR DESCRIPTION
#### Summary

Fixes many issues with `LineSeries ` Fill, there were some cases when it was not displayed correctly,
This changes also Introduce a new Property **LineSeries.AreaLimit** by default is ` double.Nan` which means the current behavior (set the fill to the bottom of the chart) but if you set a value, for example `0`, the fill of the series will help you to highlight when your series changes from positive to negative, here is an example:

![new](https://cloud.githubusercontent.com/assets/10853349/19866393/925bac78-9f65-11e6-8433-439fd97ed2ea.gif)

#### Solves 

#328 
