### PR TITLE
Resolve NullReferenceException when DrawsHeatRange = false

### DIFF
--- a/UwpView/HeatSeries.cs
+++ b/UwpView/HeatSeries.cs
@@ -148,6 +148,7 @@ namespace LiveCharts.Uwp
             pbv.Rectangle.StrokeThickness = StrokeThickness;
             pbv.Rectangle.Visibility = Visibility;
             pbv.Rectangle.StrokeDashArray = StrokeDashArray;
+
             Canvas.SetZIndex(pbv.Rectangle, Canvas.GetZIndex(pbv.Rectangle));
 
             if (Model.Chart.RequiresHoverShape && pbv.HoverShape == null)
@@ -236,12 +237,15 @@ namespace LiveCharts.Uwp
 
         public override void PlaceSpecializedElements()
         {
-            ColorRangeControl.UpdateFill(GradientStopCollection);
+            if (DrawsHeatRange)
+            {
+                ColorRangeControl.UpdateFill(GradientStopCollection);
 
-            ColorRangeControl.Height = Model.Chart.DrawMargin.Height;
+                ColorRangeControl.Height = Model.Chart.DrawMargin.Height;
 
-            Canvas.SetTop(ColorRangeControl, Model.Chart.DrawMargin.Top);
-            Canvas.SetLeft(ColorRangeControl, Model.Chart.DrawMargin.Left + Model.Chart.DrawMargin.Width + 4);
+                Canvas.SetTop(ColorRangeControl, Model.Chart.DrawMargin.Top);
+                Canvas.SetLeft(ColorRangeControl, Model.Chart.DrawMargin.Left + Model.Chart.DrawMargin.Width + 4);
+            }
         }
 
         #endregion

--- a/UwpView/UwpView.csproj
+++ b/UwpView/UwpView.csproj
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <GenerateLibraryLayout>false</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -36,6 +37,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\LiveCharts.Uwp.XML</DocumentationFile>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -59,6 +61,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <DocumentationFile>bin\Debug\LiveCharts.Uwp.XML</DocumentationFile>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>
@@ -82,6 +85,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <DocumentationFile>bin\Debug\LiveCharts.Uwp.XML</DocumentationFile>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
@@ -105,6 +109,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <DocumentationFile>bin\Debug\LiveCharts.Uwp.XML</DocumentationFile>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
@@ -237,6 +242,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'r86|x86'">
     <OutputPath>bin\x86\r86\</OutputPath>
@@ -288,6 +294,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'r64|x86'">
     <OutputPath>bin\x86\r64\</OutputPath>
@@ -330,6 +337,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'arm|AnyCPU'">
     <OutputPath>bin\arm\</OutputPath>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'arm|x86'">
     <OutputPath>bin\x86\arm\</OutputPath>

--- a/UwpView/UwpView.nuspec
+++ b/UwpView/UwpView.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>LiveCharts.Uwp</id>
-    <version>0.0.0.0</version>
+    <version>0.8.0.0</version>
     <title>LiveCharts.Uwp</title>
     <authors>Beto Rodriguez</authors>
     <owners>Beto Rodriguez</owners>
@@ -15,7 +15,7 @@
     <copyright>Copyright 2016</copyright>
     <tags>Chart Charting Plot Plotting</tags>
     <dependencies>
-      <dependency id="LiveCharts" version="0.0.0.0" />
+      <dependency id="LiveCharts" version="0.8.0.0" />
       <dependency id="Microsoft.Xaml.Behaviors.Uwp.Managed" version="2.0.0.0" />
     </dependencies>
   </metadata>
@@ -30,13 +30,13 @@
     <file src="bin\x64\LiveCharts.Uwp.dll" target="runtimes\win10-x64\native"/>
     <file src="bin\x64\LiveCharts.Uwp.pdb" target="runtimes\win10-x64\native"/>    
     <file src="bin\x64\LiveCharts.Uwp.xml" target="runtimes\win10-x64\native"/>
-    <file src="bin\x64\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native\LiveCharts.Uwp"/>
-    <file src="bin\x64\*.xbf" target="runtimes\win10-arm\native\LiveCharts.Uwp\Themes"/>
+    <file src="bin\x64\LiveCharts.Uwp.xr.xml" target="runtimes\win10-x64\native\LiveCharts.Uwp"/>
+    <file src="bin\x64\*.xbf" target="runtimes\win10-x64\native\LiveCharts.Uwp\Themes"/>
     
     <file src="bin\x86\LiveCharts.Uwp.dll" target="runtimes\win10-x86\native"/>
     <file src="bin\x86\LiveCharts.Uwp.pdb" target="runtimes\win10-x86\native"/>    
     <file src="bin\x86\LiveCharts.Uwp.xml" target="runtimes\win10-x86\native"/>
     <file src="bin\x86\LiveCharts.Uwp.xr.xml" target="runtimes\win10-x86\native\LiveCharts.Uwp"/>
-    <file src="bin\x86\*.xbf" target="runtimes\win10-arm\native\LiveCharts.Uwp\Themes"/>
+    <file src="bin\x86\*.xbf" target="runtimes\win10-x86\native\LiveCharts.Uwp\Themes"/>
   </files>
 </package>

--- a/UwpView/UwpView.nuspec
+++ b/UwpView/UwpView.nuspec
@@ -21,22 +21,10 @@
   </metadata>
   <files>
     <file src="install.ps1" target="tools" /> 
-    <file src="bin\ARM\LiveCharts.Uwp.dll" target="runtimes\win10-arm\native"/>
-    <file src="bin\ARM\LiveCharts.Uwp.pdb" target="runtimes\win10-arm\native"/>    
-    <file src="bin\ARM\LiveCharts.Uwp.xml" target="runtimes\win10-arm\native"/>
-    <file src="bin\ARM\LiveCharts.Uwp.pri" target="runtimes\win10-arm\native"/>
-    <file src="bin\ARM\LiveCharts.Uwp\*.*" target="runtimes\win10-arm\native\LiveCharts.Uwp"/>
-    
-    <file src="bin\x64\LiveCharts.Uwp.dll" target="runtimes\win10-x64\native"/>
-    <file src="bin\x64\LiveCharts.Uwp.pdb" target="runtimes\win10-x64\native"/>    
-    <file src="bin\x64\LiveCharts.Uwp.xml" target="runtimes\win10-x64\native"/>  
-    <file src="bin\x64\LiveCharts.Uwp.pri" target="runtimes\win10-x64\native"/>
-    <file src="bin\x64\LiveCharts.Uwp\*.*" target="runtimes\win10-x64\native\LiveCharts.Uwp"/>
-    
-    <file src="bin\x86\LiveCharts.Uwp.dll" target="runtimes\win10-x86\native"/>
-    <file src="bin\x86\LiveCharts.Uwp.pdb" target="runtimes\win10-x86\native"/>    
-    <file src="bin\x86\LiveCharts.Uwp.xml" target="runtimes\win10-x86\native"/>   
-    <file src="bin\x86\LiveCharts.Uwp.pri" target="runtimes\win10-x86\native"/>
-    <file src="bin\x86\LiveCharts.Uwp\*.*" target="runtimes\win10-x86\native\LiveCharts.Uwp"/>
+    <file src="bin\AnyCPU\LiveCharts.Uwp.dll" target="lib\uap10.0"/>
+    <file src="bin\AnyCPU\LiveCharts.Uwp.pdb" target="lib\uap10.0"/>    
+    <file src="bin\AnyCPU\LiveCharts.Uwp.xml" target="lib\uap10.0"/>
+    <file src="bin\AnyCPU\LiveCharts.Uwp.pri" target="lib\uap10.0"/>
+    <file src="bin\AnyCPU\LiveCharts.Uwp\*.*" target="lib\uap10.0\LiveCharts.Uwp"/>
   </files>
 </package>

--- a/UwpView/UwpView.nuspec
+++ b/UwpView/UwpView.nuspec
@@ -25,15 +25,18 @@
     <file src="bin\ARM\LiveCharts.Uwp.pdb" target="runtimes\win10-arm\native"/>    
     <file src="bin\ARM\LiveCharts.Uwp.xml" target="runtimes\win10-arm\native"/>
     <file src="bin\ARM\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native\LiveCharts.Uwp"/>
+    <file src="bin\ARM\*.xbf" target="runtimes\win10-arm\native\LiveCharts.Uwp\Themes"/>
     
     <file src="bin\x64\LiveCharts.Uwp.dll" target="runtimes\win10-x64\native"/>
     <file src="bin\x64\LiveCharts.Uwp.pdb" target="runtimes\win10-x64\native"/>    
     <file src="bin\x64\LiveCharts.Uwp.xml" target="runtimes\win10-x64\native"/>
-    <file src="bin\ARM\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native\LiveCharts.Uwp"/>
+    <file src="bin\x64\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native\LiveCharts.Uwp"/>
+    <file src="bin\x64\*.xbf" target="runtimes\win10-arm\native\LiveCharts.Uwp\Themes"/>
     
     <file src="bin\x86\LiveCharts.Uwp.dll" target="runtimes\win10-x86\native"/>
     <file src="bin\x86\LiveCharts.Uwp.pdb" target="runtimes\win10-x86\native"/>    
     <file src="bin\x86\LiveCharts.Uwp.xml" target="runtimes\win10-x86\native"/>
     <file src="bin\x86\LiveCharts.Uwp.xr.xml" target="runtimes\win10-x86\native\LiveCharts.Uwp"/>
+    <file src="bin\x86\*.xbf" target="runtimes\win10-arm\native\LiveCharts.Uwp\Themes"/>
   </files>
 </package>

--- a/UwpView/UwpView.nuspec
+++ b/UwpView/UwpView.nuspec
@@ -24,19 +24,19 @@
     <file src="bin\ARM\LiveCharts.Uwp.dll" target="runtimes\win10-arm\native"/>
     <file src="bin\ARM\LiveCharts.Uwp.pdb" target="runtimes\win10-arm\native"/>    
     <file src="bin\ARM\LiveCharts.Uwp.xml" target="runtimes\win10-arm\native"/>
-    <file src="bin\ARM\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native\LiveCharts.Uwp"/>
-    <file src="bin\ARM\*.xbf" target="runtimes\win10-arm\native\LiveCharts.Uwp\Themes"/>
+    <file src="bin\ARM\LiveCharts.Uwp.pri" target="runtimes\win10-arm\native"/>
+    <file src="bin\ARM\LiveCharts.Uwp\*.*" target="runtimes\win10-arm\native\LiveCharts.Uwp"/>
     
     <file src="bin\x64\LiveCharts.Uwp.dll" target="runtimes\win10-x64\native"/>
     <file src="bin\x64\LiveCharts.Uwp.pdb" target="runtimes\win10-x64\native"/>    
-    <file src="bin\x64\LiveCharts.Uwp.xml" target="runtimes\win10-x64\native"/>
-    <file src="bin\x64\LiveCharts.Uwp.xr.xml" target="runtimes\win10-x64\native\LiveCharts.Uwp"/>
-    <file src="bin\x64\*.xbf" target="runtimes\win10-x64\native\LiveCharts.Uwp\Themes"/>
+    <file src="bin\x64\LiveCharts.Uwp.xml" target="runtimes\win10-x64\native"/>  
+    <file src="bin\x64\LiveCharts.Uwp.pri" target="runtimes\win10-x64\native"/>
+    <file src="bin\x64\LiveCharts.Uwp\*.*" target="runtimes\win10-x64\native\LiveCharts.Uwp"/>
     
     <file src="bin\x86\LiveCharts.Uwp.dll" target="runtimes\win10-x86\native"/>
     <file src="bin\x86\LiveCharts.Uwp.pdb" target="runtimes\win10-x86\native"/>    
-    <file src="bin\x86\LiveCharts.Uwp.xml" target="runtimes\win10-x86\native"/>
-    <file src="bin\x86\LiveCharts.Uwp.xr.xml" target="runtimes\win10-x86\native\LiveCharts.Uwp"/>
-    <file src="bin\x86\*.xbf" target="runtimes\win10-x86\native\LiveCharts.Uwp\Themes"/>
+    <file src="bin\x86\LiveCharts.Uwp.xml" target="runtimes\win10-x86\native"/>   
+    <file src="bin\x86\LiveCharts.Uwp.pri" target="runtimes\win10-x86\native"/>
+    <file src="bin\x86\LiveCharts.Uwp\*.*" target="runtimes\win10-x86\native\LiveCharts.Uwp"/>
   </files>
 </package>

--- a/UwpView/UwpView.nuspec
+++ b/UwpView/UwpView.nuspec
@@ -24,11 +24,16 @@
     <file src="bin\ARM\LiveCharts.Uwp.dll" target="runtimes\win10-arm\native"/>
     <file src="bin\ARM\LiveCharts.Uwp.pdb" target="runtimes\win10-arm\native"/>    
     <file src="bin\ARM\LiveCharts.Uwp.xml" target="runtimes\win10-arm\native"/>
+    <file src="bin\ARM\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native"/>
+    
     <file src="bin\x64\LiveCharts.Uwp.dll" target="runtimes\win10-x64\native"/>
     <file src="bin\x64\LiveCharts.Uwp.pdb" target="runtimes\win10-x64\native"/>    
     <file src="bin\x64\LiveCharts.Uwp.xml" target="runtimes\win10-x64\native"/>
+    <file src="bin\ARM\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native"/>
+    
     <file src="bin\x86\LiveCharts.Uwp.dll" target="runtimes\win10-x86\native"/>
     <file src="bin\x86\LiveCharts.Uwp.pdb" target="runtimes\win10-x86\native"/>    
     <file src="bin\x86\LiveCharts.Uwp.xml" target="runtimes\win10-x86\native"/>
+    <file src="bin\x86\LiveCharts.Uwp.xr.xml" target="runtimes\win10-x86\native"/>
   </files>
 </package>

--- a/UwpView/UwpView.nuspec
+++ b/UwpView/UwpView.nuspec
@@ -24,16 +24,16 @@
     <file src="bin\ARM\LiveCharts.Uwp.dll" target="runtimes\win10-arm\native"/>
     <file src="bin\ARM\LiveCharts.Uwp.pdb" target="runtimes\win10-arm\native"/>    
     <file src="bin\ARM\LiveCharts.Uwp.xml" target="runtimes\win10-arm\native"/>
-    <file src="bin\ARM\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native"/>
+    <file src="bin\ARM\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native\LiveCharts.Uwp"/>
     
     <file src="bin\x64\LiveCharts.Uwp.dll" target="runtimes\win10-x64\native"/>
     <file src="bin\x64\LiveCharts.Uwp.pdb" target="runtimes\win10-x64\native"/>    
     <file src="bin\x64\LiveCharts.Uwp.xml" target="runtimes\win10-x64\native"/>
-    <file src="bin\ARM\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native"/>
+    <file src="bin\ARM\LiveCharts.Uwp.xr.xml" target="runtimes\win10-arm\native\LiveCharts.Uwp"/>
     
     <file src="bin\x86\LiveCharts.Uwp.dll" target="runtimes\win10-x86\native"/>
     <file src="bin\x86\LiveCharts.Uwp.pdb" target="runtimes\win10-x86\native"/>    
     <file src="bin\x86\LiveCharts.Uwp.xml" target="runtimes\win10-x86\native"/>
-    <file src="bin\x86\LiveCharts.Uwp.xr.xml" target="runtimes\win10-x86\native"/>
+    <file src="bin\x86\LiveCharts.Uwp.xr.xml" target="runtimes\win10-x86\native\LiveCharts.Uwp"/>
   </files>
 </package>

--- a/UwpView/project.json
+++ b/UwpView/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0"
+    "Microsoft.Xaml.Behaviors.Uwp.Managed": "2.0.0"
   },
   "frameworks": {
     "uap10.0": {}

--- a/build.cake
+++ b/build.cake
@@ -79,15 +79,11 @@ Task("UWP")
     {
         Information("-- UWP - " + buildType.ToUpper() + " --");
 
-        if(!DirectoryExists("./bin/Arm")) CreateDirectory("./bin/Arm");
-        if(!DirectoryExists("./bin/x64")) CreateDirectory("./bin/x64");
-        if(!DirectoryExists("./bin/x86")) CreateDirectory("./bin/x86");
+        if(!DirectoryExists("./bin/AnyCPU")) CreateDirectory("./bin/AnyCPU");
         
-        BuildProject("./UwpView/UwpView.csproj", "./bin/Arm", buildType, "ARM");
-        BuildProject("./UwpView/UwpView.csproj", "./bin/x64", buildType, "x64");
-        BuildProject("./UwpView/UwpView.csproj", "./bin/x86", buildType, "x86");
+        BuildProject("./UwpView/UwpView.csproj", "./bin/AnyCPU", buildType, "AnyCPU");
 
-        if(buildType == "Release") NugetPack("./UwpView/UwpView.nuspec", "./UwpView/bin/x86/LiveCharts.Uwp.dll");
+        if(buildType == "Release") NugetPack("./UwpView/UwpView.nuspec", "./UwpView/bin/AnyCPU/LiveCharts.Uwp.dll");
 
         Information("-- UWP Packed --");
     });

--- a/build.cake
+++ b/build.cake
@@ -87,7 +87,7 @@ Task("UWP")
         BuildProject("./UwpView/UwpView.csproj", "./bin/x64", buildType, "x64");
         BuildProject("./UwpView/UwpView.csproj", "./bin/x86", buildType, "x86");
 
-        if(buildType == "Release") NugetPack("./UwpView/UwpView.nuspec", "./UwpView/bin/Release/LiveCharts.Uwp.dll");
+        if(buildType == "Release") NugetPack("./UwpView/UwpView.nuspec", "./UwpView/bin/x86/LiveCharts.Uwp.dll");
 
         Information("-- UWP Packed --");
     });


### PR DESCRIPTION
#### Summary

Resolve NullReferenceException when DrawsHeatRange = false
Fixed up nuget packaging for UWP assemblies.

#### Solves 

NullReferenceException in HeatSeries when DrawsHeatRange = false
'LiveCharts.Uwp.dll' not found when packaging UWP into nuget package

