### PR TITLE
Make HeatPoint respect HeatSeries.Margin

### DIFF
--- a/UwpView/HeatSeries.cs
+++ b/UwpView/HeatSeries.cs
@@ -148,6 +148,7 @@ namespace LiveCharts.Uwp
             pbv.Rectangle.StrokeThickness = StrokeThickness;
             pbv.Rectangle.Visibility = Visibility;
             pbv.Rectangle.StrokeDashArray = StrokeDashArray;
+            pbv.Rectangle.Margin = Margin;
 
             Canvas.SetZIndex(pbv.Rectangle, Canvas.GetZIndex(pbv.Rectangle));
 

--- a/UwpView/Points/HeatPoint.cs
+++ b/UwpView/Points/HeatPoint.cs
@@ -40,11 +40,11 @@ namespace LiveCharts.Uwp.Points
 
         public override void DrawOrMove(ChartPoint previousDrawn, ChartPoint current, int index, ChartCore chart)
         {
-            Canvas.SetTop(Rectangle, current.ChartLocation.Y);
-            Canvas.SetLeft(Rectangle, current.ChartLocation.X);
+            Canvas.SetTop(Rectangle, current.ChartLocation.Y + Rectangle.Margin.Top);
+            Canvas.SetLeft(Rectangle, current.ChartLocation.X + Rectangle.Margin.Left);
 
-            Rectangle.Width = Width;
-            Rectangle.Height = Height;
+            Rectangle.Width = Width - Rectangle.Margin.Left - Rectangle.Margin.Right;
+            Rectangle.Height = Height - Rectangle.Margin.Top - Rectangle.Margin.Bottom;
 
             if (IsNew)
             {


### PR DESCRIPTION
#### Summary

I wanted a heat map that looked like Github's contribution chart. To do this I needed space around each of the data points. HeatSeries already exposed a Margin property so I simply copied this onto the Rectangle property of the HeatPoint and amended DrawOrMove to respect it.

#### Solves 



