### PR TITLE
HeatAlgorithm color interpolation

### DIFF
--- a/Core/SeriesAlgorithms/HeatAlgorithm.cs
+++ b/Core/SeriesAlgorithms/HeatAlgorithm.cs
@@ -137,7 +137,7 @@ namespace LiveCharts.SeriesAlgorithms
 
             return new CoreColor(
                 InterpolateColorComponent(from.A, to.A, fromOffset, toOffset, weight),
-                InterpolateColorComponent(from.R, from.R, fromOffset, toOffset, weight),
+                InterpolateColorComponent(from.R, to.R, fromOffset, toOffset, weight),
                 InterpolateColorComponent(from.G, to.G, fromOffset, toOffset, weight),
                 InterpolateColorComponent(from.B, to.B, fromOffset, toOffset, weight));
         }
@@ -145,14 +145,18 @@ namespace LiveCharts.SeriesAlgorithms
         private static byte InterpolateColorComponent(byte fromComponent, byte toComponent,
             double fromOffset, double toOffset, double value)
         {
-            var p1 = new CorePoint(fromOffset, fromComponent);
-            var p2 = new CorePoint(toOffset, toComponent);
+            if (fromComponent == toComponent)
+            {
+                return fromComponent;
+            }
+            else
+            {
+                var deltaX = toOffset - fromOffset;
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                var m = (toComponent - fromComponent) / (deltaX == 0 ? double.MinValue : deltaX);
 
-            var deltaX = p2.X - p1.X;
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            var m = (p2.Y - p1.Y) / (deltaX == 0 ? double.MinValue : deltaX);
-
-            return (byte)(m * (value - p1.X) + p1.Y);
+                return (byte)(m * (value - fromOffset) + fromComponent);
+            }
         }
     }
 }

--- a/UwpView/HeatSeries.cs
+++ b/UwpView/HeatSeries.cs
@@ -148,6 +148,7 @@ namespace LiveCharts.Uwp
             pbv.Rectangle.StrokeThickness = StrokeThickness;
             pbv.Rectangle.Visibility = Visibility;
             pbv.Rectangle.StrokeDashArray = StrokeDashArray;
+            pbv.Rectangle.Margin = Margin;
 
             Canvas.SetZIndex(pbv.Rectangle, Canvas.GetZIndex(pbv.Rectangle));
 

--- a/UwpView/Points/HeatPoint.cs
+++ b/UwpView/Points/HeatPoint.cs
@@ -40,11 +40,11 @@ namespace LiveCharts.Uwp.Points
 
         public override void DrawOrMove(ChartPoint previousDrawn, ChartPoint current, int index, ChartCore chart)
         {
-            Canvas.SetTop(Rectangle, current.ChartLocation.Y);
-            Canvas.SetLeft(Rectangle, current.ChartLocation.X);
+            Canvas.SetTop(Rectangle, current.ChartLocation.Y + Rectangle.Margin.Top);
+            Canvas.SetLeft(Rectangle, current.ChartLocation.X + Rectangle.Margin.Left);
 
-            Rectangle.Width = Width;
-            Rectangle.Height = Height;
+            Rectangle.Width = Width - Rectangle.Margin.Left - Rectangle.Margin.Right;
+            Rectangle.Height = Height - Rectangle.Margin.Top - Rectangle.Margin.Bottom;
 
             if (IsNew)
             {


### PR DESCRIPTION
#### Summary

Bug fix and optimization for HeatAlgorithm

#### Solves 

Fixed bug in ColorInterpolation where Red component was being interpolated from and to the same value.
Optimized InterpolateColorComponent by removing CorePoint allocations and adding short-circuit when interpolating between the same values.
