### PR TITLE
Allow labels rotation in bar series

### DIFF
--- a/Core/BarLabelPosition.cs
+++ b/Core/BarLabelPosition.cs
@@ -20,6 +20,8 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
+using System;
+
 namespace LiveCharts
 {
     /// <summary>
@@ -34,6 +36,15 @@ namespace LiveCharts
         /// <summary>
         /// Places a labels inside the bar
         /// </summary>
-        Merged
+        [Obsolete("Instead use BarLabelPosition.Parallel")]
+        Merged,
+        /// <summary>
+        /// Places a labels in a parallel orientation to the bar height.
+        /// </summary>
+        Parallel,
+        /// <summary>
+        /// Places a labels in a perpendicular orientation to the bar height.
+        /// </summary>
+        Perpendicular
     }
 }

--- a/UwpView/Points/ColumnPointView.cs
+++ b/UwpView/Points/ColumnPointView.cs
@@ -23,7 +23,6 @@
 using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 using LiveCharts.Charts;
@@ -39,7 +38,7 @@ namespace LiveCharts.Uwp.Points
         public CoreRectangle Data { get; set; }
         public double ZeroReference  { get; set; }
         public BarLabelPosition LabelPosition { get; set; }
-        public RotateTransform RotateTransform { get; set; }
+        private RotateTransform Transform { get; set; }
 
         public override void DrawOrMove(ChartPoint previousDrawn, ChartPoint current, int index, ChartCore chart)
         {
@@ -57,19 +56,24 @@ namespace LiveCharts.Uwp.Points
                     Canvas.SetLeft(DataLabel, current.ChartLocation.X);
                 }
             }
-          
+
             Func<double> getY = () =>
             {
                 double y;
 
-                if (LabelPosition == BarLabelPosition.Merged)
+#pragma warning disable 618
+                if (LabelPosition == BarLabelPosition.Parallel || LabelPosition == BarLabelPosition.Merged)
+#pragma warning restore 618
                 {
-                    if (RotateTransform == null)
-                        RotateTransform = new RotateTransform() {Angle = 270 };
+                    if (Transform == null)
+                        Transform = new RotateTransform {Angle = 270};
 
-                    DataLabel.RenderTransform = RotateTransform;
-
-                    y = Data.Top + Data.Height/2 + DataLabel.ActualWidth*.5;
+                    y = Data.Top + Data.Height / 2 + DataLabel.ActualWidth * .5;
+                    DataLabel.RenderTransform = Transform;
+                }
+                else if (LabelPosition == BarLabelPosition.Perpendicular)
+                {
+                    y = Data.Top + Data.Height / 2 - DataLabel.ActualHeight * .5;
                 }
                 else
                 {
@@ -92,9 +96,15 @@ namespace LiveCharts.Uwp.Points
             {
                 double x;
 
-                if (LabelPosition == BarLabelPosition.Merged)
+#pragma warning disable 618
+                if (LabelPosition == BarLabelPosition.Parallel || LabelPosition == BarLabelPosition.Merged)
+#pragma warning restore 618
                 {
-                    x = Data.Left + Data.Width/2 - DataLabel.ActualHeight/2;
+                    x = Data.Left + Data.Width / 2 - DataLabel.ActualHeight / 2;
+                }
+                else if (LabelPosition == BarLabelPosition.Perpendicular)
+                {
+                    x = Data.Left + Data.Width / 2 - DataLabel.ActualWidth / 2;
                 }
                 else
                 {

--- a/UwpView/Points/RowPointView.cs
+++ b/UwpView/Points/RowPointView.cs
@@ -37,6 +37,7 @@ namespace LiveCharts.Uwp.Points
         public CoreRectangle Data { get; set; }
         public double ZeroReference  { get; set; }
         public BarLabelPosition LabelPosition { get; set; }
+        private RotateTransform Transform { get; set; }
 
         public override void DrawOrMove(ChartPoint previousDrawn, ChartPoint current, int index, ChartCore chart)
         {
@@ -54,9 +55,18 @@ namespace LiveCharts.Uwp.Points
                     Canvas.SetLeft(DataLabel, ZeroReference);
                 }
             }
-          
+
             Func<double> getY = () =>
             {
+                if (LabelPosition == BarLabelPosition.Perpendicular)
+                {
+                    if (Transform == null)
+                        Transform = new RotateTransform {Angle = 270};
+
+                    DataLabel.RenderTransform = Transform;
+                    return Data.Top + Data.Height / 2 + DataLabel.ActualWidth * .5;
+                }
+
                 var r = Data.Top + Data.Height / 2 - DataLabel.ActualHeight / 2;
 
                 if (r < 0) r = 2;
@@ -70,9 +80,15 @@ namespace LiveCharts.Uwp.Points
             {
                 double r;
 
-                if (LabelPosition == BarLabelPosition.Merged)
+#pragma warning disable 618
+                if (LabelPosition == BarLabelPosition.Parallel || LabelPosition == BarLabelPosition.Merged)
+#pragma warning restore 618
                 {
-                    r = Data.Left + Data.Width/2 - DataLabel.ActualWidth/2;
+                    r = Data.Left + Data.Width / 2 - DataLabel.ActualWidth / 2;
+                }
+                else if (LabelPosition == BarLabelPosition.Perpendicular)
+                {
+                    r = Data.Left + Data.Width / 2 - DataLabel.ActualHeight / 2;
                 }
                 else
                 {

--- a/UwpView/RowSeries.cs
+++ b/UwpView/RowSeries.cs
@@ -111,8 +111,6 @@ namespace LiveCharts.Uwp
             get { return (BarLabelPosition)GetValue(LabelPositionProperty); }
             set { SetValue(LabelPositionProperty, value); }
         }
-
-
         #endregion
 
         #region Overridden Methods

--- a/UwpView/StackedColumnSeries.cs
+++ b/UwpView/StackedColumnSeries.cs
@@ -109,7 +109,21 @@ namespace LiveCharts.Uwp
             get { return (StackMode) GetValue(StackModeProperty); }
             set { SetValue(StackModeProperty, value); }
         }
-
+        
+        /// <summary>
+        /// The labels position property
+        /// </summary>
+        public static readonly DependencyProperty LabelsPositionProperty = DependencyProperty.Register(
+            "LabelsPosition", typeof(BarLabelPosition), typeof(StackedColumnSeries),
+            new PropertyMetadata(BarLabelPosition.Top, CallChartUpdater()));
+        /// <summary>
+        /// Gets or sets where the label is placed
+        /// </summary>
+        public BarLabelPosition LabelsPosition
+        {
+            get { return (BarLabelPosition)GetValue(LabelsPositionProperty); }
+            set { SetValue(LabelsPositionProperty, value); }
+        }
         #endregion
 
         #region Overridden Methods
@@ -130,8 +144,7 @@ namespace LiveCharts.Uwp
                 {
                     IsNew = true,
                     Rectangle = new Rectangle(),
-                    Data = new CoreRectangle(),
-                    LabelPosition = BarLabelPosition.Merged
+                    Data = new CoreRectangle()
                 };
 
                 Model.Chart.View.AddToDrawMargin(pbv.Rectangle);
@@ -179,6 +192,8 @@ namespace LiveCharts.Uwp
             }
 
             if (pbv.DataLabel != null) pbv.DataLabel.Text = label;
+
+            pbv.LabelPosition = LabelsPosition;
 
             return pbv;
         }

--- a/UwpView/StackedRowSeries.cs
+++ b/UwpView/StackedRowSeries.cs
@@ -111,6 +111,20 @@ namespace LiveCharts.Uwp
             set { SetValue(StackModeProperty, value); }
         }
 
+        /// <summary>
+        /// The label position property
+        /// </summary>
+        public static readonly DependencyProperty LabelPositionProperty = DependencyProperty.Register(
+            "LabelPosition", typeof(BarLabelPosition), typeof(StackedRowSeries),
+            new PropertyMetadata(BarLabelPosition.Top, CallChartUpdater()));
+        /// <summary>
+        /// Gets or sets where the label is placed
+        /// </summary>
+        public BarLabelPosition LabelPosition
+        {
+            get { return (BarLabelPosition)GetValue(LabelPositionProperty); }
+            set { SetValue(LabelPositionProperty, value); }
+        }
         #endregion
 
         #region Overridden Methods
@@ -131,8 +145,7 @@ namespace LiveCharts.Uwp
                 {
                     IsNew = true,
                     Rectangle = new Rectangle(),
-                    Data = new CoreRectangle(),
-                    LabelPosition = BarLabelPosition.Merged
+                    Data = new CoreRectangle()
                 };
 
                 Model.Chart.View.AddToDrawMargin(pbv.Rectangle);
@@ -182,6 +195,8 @@ namespace LiveCharts.Uwp
             }
 
             if (pbv.DataLabel != null) pbv.DataLabel.Text = label;
+
+            pbv.LabelPosition = LabelPosition;
 
             return pbv;
         }

--- a/WpfView/Points/ColumnPointView.cs
+++ b/WpfView/Points/ColumnPointView.cs
@@ -38,7 +38,7 @@ namespace LiveCharts.Wpf.Points
         public CoreRectangle Data { get; set; }
         public double ZeroReference  { get; set; }
         public BarLabelPosition LabelPosition { get; set; }
-        public RotateTransform RotateTransform { get; set; }
+        private RotateTransform Transform { get; set; }
 
         public override void DrawOrMove(ChartPoint previousDrawn, ChartPoint current, int index, ChartCore chart)
         {
@@ -61,14 +61,19 @@ namespace LiveCharts.Wpf.Points
             {
                 double y;
 
-                if (LabelPosition == BarLabelPosition.Merged)
+#pragma warning disable 618
+                if (LabelPosition == BarLabelPosition.Parallel || LabelPosition == BarLabelPosition.Merged)
+#pragma warning restore 618
                 {
-                    if (RotateTransform == null)
-                        RotateTransform = new RotateTransform(270);
-
-                    DataLabel.RenderTransform = RotateTransform;
+                    if (Transform == null)
+                        Transform = new RotateTransform(270);
 
                     y = Data.Top + Data.Height/2 + DataLabel.ActualWidth*.5;
+                    DataLabel.RenderTransform = Transform;
+                }
+                else if (LabelPosition == BarLabelPosition.Perpendicular)
+                {
+                    y = Data.Top + Data.Height/2 - DataLabel.ActualHeight * .5;
                 }
                 else
                 {
@@ -91,9 +96,15 @@ namespace LiveCharts.Wpf.Points
             {
                 double x;
 
-                if (LabelPosition == BarLabelPosition.Merged)
+#pragma warning disable 618
+                if (LabelPosition == BarLabelPosition.Parallel || LabelPosition == BarLabelPosition.Merged)
+#pragma warning restore 618
                 {
                     x = Data.Left + Data.Width/2 - DataLabel.ActualHeight/2;
+                }
+                else if (LabelPosition == BarLabelPosition.Perpendicular)
+                {
+                    x = Data.Left + Data.Width/2 - DataLabel.ActualWidth/2;
                 }
                 else
                 {

--- a/WpfView/Points/RowPointView.cs
+++ b/WpfView/Points/RowPointView.cs
@@ -38,6 +38,7 @@ namespace LiveCharts.Wpf.Points
         public CoreRectangle Data { get; set; }
         public double ZeroReference  { get; set; }
         public BarLabelPosition LabelPosition { get; set; }
+        private RotateTransform Transform { get; set; }
 
         public override void DrawOrMove(ChartPoint previousDrawn, ChartPoint current, int index, ChartCore chart)
         {
@@ -58,6 +59,15 @@ namespace LiveCharts.Wpf.Points
           
             Func<double> getY = () =>
             {
+                if (LabelPosition == BarLabelPosition.Perpendicular)
+                {
+                    if (Transform == null)
+                        Transform = new RotateTransform(270);
+
+                    DataLabel.RenderTransform = Transform;
+                    return Data.Top + Data.Height/2 + DataLabel.ActualWidth*.5;
+                }
+
                 var r = Data.Top + Data.Height / 2 - DataLabel.ActualHeight / 2;
 
                 if (r < 0) r = 2;
@@ -71,9 +81,15 @@ namespace LiveCharts.Wpf.Points
             {
                 double r;
 
-                if (LabelPosition == BarLabelPosition.Merged)
+#pragma warning disable 618
+                if (LabelPosition == BarLabelPosition.Parallel || LabelPosition == BarLabelPosition.Merged)
+#pragma warning restore 618
                 {
                     r = Data.Left + Data.Width/2 - DataLabel.ActualWidth/2;
+                }
+                else if (LabelPosition == BarLabelPosition.Perpendicular)
+                {
+                    r = Data.Left + Data.Width/2 - DataLabel.ActualHeight/2;
                 }
                 else
                 {

--- a/WpfView/RowSeries.cs
+++ b/WpfView/RowSeries.cs
@@ -110,8 +110,6 @@ namespace LiveCharts.Wpf
             get { return (BarLabelPosition)GetValue(LabelsPositionProperty); }
             set { SetValue(LabelsPositionProperty, value); }
         }
-
-
         #endregion
 
         #region Overridden Methods

--- a/WpfView/StackedColumnSeries.cs
+++ b/WpfView/StackedColumnSeries.cs
@@ -108,7 +108,21 @@ namespace LiveCharts.Wpf
             get { return (StackMode) GetValue(StackModeProperty); }
             set { SetValue(StackModeProperty, value); }
         }
-
+        
+        /// <summary>
+        /// The labels position property
+        /// </summary>
+        public static readonly DependencyProperty LabelsPositionProperty = DependencyProperty.Register(
+            "LabelsPosition", typeof(BarLabelPosition), typeof(StackedColumnSeries),
+            new PropertyMetadata(default(BarLabelPosition), CallChartUpdater()));
+        /// <summary>
+        /// Gets or sets where the label is placed
+        /// </summary>
+        public BarLabelPosition LabelsPosition
+        {
+            get { return (BarLabelPosition)GetValue(LabelsPositionProperty); }
+            set { SetValue(LabelsPositionProperty, value); }
+        }
         #endregion
 
         #region Overridden Methods
@@ -129,8 +143,7 @@ namespace LiveCharts.Wpf
                 {
                     IsNew = true,
                     Rectangle = new Rectangle(),
-                    Data = new CoreRectangle(),
-                    LabelPosition = BarLabelPosition.Merged
+                    Data = new CoreRectangle()
                 };
 
                 Model.Chart.View.AddToDrawMargin(pbv.Rectangle);
@@ -178,6 +191,8 @@ namespace LiveCharts.Wpf
             }
 
             if (pbv.DataLabel != null) pbv.DataLabel.Text = label;
+
+            pbv.LabelPosition = LabelsPosition;
 
             return pbv;
         }

--- a/WpfView/StackedRowSeries.cs
+++ b/WpfView/StackedRowSeries.cs
@@ -110,6 +110,20 @@ namespace LiveCharts.Wpf
             set { SetValue(StackModeProperty, value); }
         }
 
+        /// <summary>
+        /// The labels position property
+        /// </summary>
+        public static readonly DependencyProperty LabelsPositionProperty = DependencyProperty.Register(
+            "LabelsPosition", typeof(BarLabelPosition), typeof(StackedRowSeries),
+            new PropertyMetadata(default(BarLabelPosition), CallChartUpdater()));
+        /// <summary>
+        /// Gets or sets where the label is placed
+        /// </summary>
+        public BarLabelPosition LabelsPosition
+        {
+            get { return (BarLabelPosition)GetValue(LabelsPositionProperty); }
+            set { SetValue(LabelsPositionProperty, value); }
+        }
         #endregion
 
         #region Overridden Methods
@@ -130,8 +144,7 @@ namespace LiveCharts.Wpf
                 {
                     IsNew = true,
                     Rectangle = new Rectangle(),
-                    Data = new CoreRectangle(),
-                    LabelPosition = BarLabelPosition.Merged
+                    Data = new CoreRectangle()
                 };
 
                 Model.Chart.View.AddToDrawMargin(pbv.Rectangle);
@@ -181,6 +194,8 @@ namespace LiveCharts.Wpf
             }
 
             if (pbv.DataLabel != null) pbv.DataLabel.Text = label;
+
+            pbv.LabelPosition = LabelsPosition;
 
             return pbv;
         }


### PR DESCRIPTION
#### Summary

Now we can specify the labels orientation in any bar series (Row, StackedRow, column and StackedColumn) 

Options are:

* Top 
* Parallel
* Perpendicular
* --Merged-- (Obsolete, replaced with Parallel) 

**Top**

![untitled](https://cloud.githubusercontent.com/assets/10853349/21028448/d98357dc-bd5a-11e6-9178-ce4660a2c13a.png)

**Parallel and merged**

![untitled](https://cloud.githubusercontent.com/assets/10853349/21028473/f817c016-bd5a-11e6-9ae7-9f9385d47c39.png)

**Perpendicular**

![untitled](https://cloud.githubusercontent.com/assets/10853349/21028505/18b446b4-bd5b-11e6-915e-1f19825671f8.png)


#### Solves 

fixes #308 
