### PR TITLE
Add DataHover event based on DataClick event.

### DIFF
--- a/Core/Definitions/Charts/IChartView.cs
+++ b/Core/Definitions/Charts/IChartView.cs
@@ -48,6 +48,11 @@ namespace LiveCharts.Definitions.Charts
         event DataClickHandler DataClick;
 
         /// <summary>
+        /// Occurs when [data hover]
+        /// </summary>
+        event DataHoverHandler DataHover;
+
+        /// <summary>
         /// Gets or sets a value indicating whether this instance is mocked.
         /// </summary>
         /// <value>
@@ -132,6 +137,12 @@ namespace LiveCharts.Definitions.Charts
         /// <c>true</c> if this instance has data click event attached; otherwise, <c>false</c>.
         /// </value>
         bool HasDataClickEventAttached { get; }
+        /// Gets a value indicating whether this instance has data hover event attached.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has data hover event attached; otherwise, <c>false</c>.
+        /// </value>
+        bool HasDataHoverEventAttached { get; }
         /// <summary>
         /// Gets a value indicating whether this <see cref="IChartView"/> is hoverable.
         /// </summary>

--- a/Core/Events/Delegates.cs
+++ b/Core/Events/Delegates.cs
@@ -32,6 +32,13 @@ namespace LiveCharts.Events
     /// <summary>
     /// 
     /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="chartPoint"></param>
+    public delegate void DataHoverHandler(object sender, ChartPoint chartPoint);
+
+    /// <summary>
+    /// 
+    /// </summary>
     public delegate void UpdaterTickHandler();
 
     /// <summary>

--- a/Core40/Definitions/Charts/IChartView.cs
+++ b/Core40/Definitions/Charts/IChartView.cs
@@ -48,6 +48,11 @@ namespace LiveCharts.Definitions.Charts
         event DataClickHandler DataClick;
 
         /// <summary>
+        /// Occurs when [data hover]
+        /// </summary>
+        event DataHoverHandler DataHover;
+
+        /// <summary>
         /// Gets or sets a value indicating whether this instance is mocked.
         /// </summary>
         /// <value>
@@ -132,6 +137,12 @@ namespace LiveCharts.Definitions.Charts
         /// <c>true</c> if this instance has data click event attached; otherwise, <c>false</c>.
         /// </value>
         bool HasDataClickEventAttached { get; }
+        /// Gets a value indicating whether this instance has data hover event attached.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has data hover event attached; otherwise, <c>false</c>.
+        /// </value>
+        bool HasDataHoverEventAttached { get; }
         /// <summary>
         /// Gets a value indicating whether this <see cref="IChartView"/> is hoverable.
         /// </summary>

--- a/Core40/Events/Delegates.cs
+++ b/Core40/Events/Delegates.cs
@@ -32,6 +32,13 @@ namespace LiveCharts.Events
     /// <summary>
     /// 
     /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="chartPoint"></param>
+    public delegate void DataHoverHandler(object sender, ChartPoint chartPoint);
+
+    /// <summary>
+    /// 
+    /// </summary>
     public delegate void UpdaterTickHandler();
 
     /// <summary>

--- a/UwpView/Charts/Base/Chart.cs
+++ b/UwpView/Charts/Base/Chart.cs
@@ -239,6 +239,11 @@ namespace LiveCharts.Uwp.Charts.Base
         public event DataClickHandler DataClick;
 
         /// <summary>
+        /// The DataHover event is fired when a user hovers over any data point
+        /// </summary>
+        public event DataHoverHandler DataHover;
+
+        /// <summary>
         /// This event is fired every time the chart updates.
         /// </summary>
         public event UpdaterTickHandler UpdaterTick;
@@ -582,6 +587,11 @@ namespace LiveCharts.Uwp.Charts.Base
         /// Gets whether the chart has a DataClick event attacked.
         /// </summary>
         public bool HasDataClickEventAttached => DataClick != null;
+
+        /// <summary>
+        /// Gets whether the chart has a DataHover event attached
+        /// </summary>
+        public bool HasDataHoverEventAttached => DataHover != null;
 
         /// <summary>
         /// Gets whether the chart is already loaded in the view.

--- a/UwpView/Charts/Base/Chart.cs
+++ b/UwpView/Charts/Base/Chart.cs
@@ -1017,6 +1017,13 @@ namespace LiveCharts.Uwp.Charts.Base
                     storyBoard.Begin();
                 }
             }
+
+            OnDataHover(sender, senderPoint);
+        }
+
+        internal void OnDataHover(object sender, ChartPoint point)
+        {
+            if (DataHover != null) DataHover.Invoke(sender, point);
         }
 
         private void DataMouseLeave(object sender, PointerRoutedEventArgs e)

--- a/WpfView/Charts/Base/Chart.cs
+++ b/WpfView/Charts/Base/Chart.cs
@@ -227,6 +227,11 @@ namespace LiveCharts.Wpf.Charts.Base
         public event DataClickHandler DataClick;
 
         /// <summary>
+        /// The DataHover event is fired when a user hovers over any data point
+        /// </summary>
+        public event DataHoverHandler DataHover;
+
+        /// <summary>
         /// This event is fired every time the chart updates.
         /// </summary>
         public event UpdaterTickHandler UpdaterTick;
@@ -561,6 +566,14 @@ namespace LiveCharts.Wpf.Charts.Base
         public bool HasDataClickEventAttached
         {
             get { return DataClick != null; }
+        }
+
+        /// <summary>
+        /// Gets whether the chart has a DataHover event attached
+        /// </summary>
+        public bool HasDataHoverEventAttached
+        {
+            get { return DataHover != null; }
         }
 
         /// <summary>
@@ -968,6 +981,13 @@ namespace LiveCharts.Wpf.Charts.Base
                         new DoubleAnimation(location.Y, TimeSpan.FromMilliseconds(200)));
                 }
             }
+
+            OnDataHover(sender, senderPoint);
+        }
+
+        internal void OnDataHover(object sender, ChartPoint point)
+        {
+            if (DataHover != null) DataHover.Invoke(sender, point);
         }
 
         private void DataMouseLeave(object sender, EventArgs e)


### PR DESCRIPTION
#### Summary

Based on the DataClick event, the DataHover event allows users to add an event on DataMouseEnter. This can be useful for various interactivity features. The feature is written for WpfView and UwpView.

#### Solves 
