### PR TITLE
fixe case when from, to and value are 0

### DIFF
--- a/WpfView/Gauge.cs
+++ b/WpfView/Gauge.cs
@@ -313,6 +313,11 @@ namespace LiveCharts.Wpf
 
             var t = 0d;
 
+            if (double.IsNaN(completed) || double.IsInfinity(completed))
+            {
+                completed = 0;
+            }
+
             completed = completed > 1 ? 1 : (completed < 0 ? 0 : completed);
             var angle = Uses360Mode ? 360 : 180;
 


### PR DESCRIPTION
#### Summary

Handles case when from, to and value are 0 in Gauge control.

#### Solves 

fixes #420 
