### PR TITLE
A Flexible default tooltip

### DIFF
--- a/UwpView/DefaultLegend.xaml.cs
+++ b/UwpView/DefaultLegend.xaml.cs
@@ -30,20 +30,6 @@ using LiveCharts.Uwp.Components.MultiBinding;
 namespace LiveCharts.Uwp
 {
     /// <summary>
-    /// 
-    /// </summary>
-    public interface IChartLegend
-    {
-        /// <summary>
-        /// Gets or sets the series.
-        /// </summary>
-        /// <value>
-        /// The series.
-        /// </value>
-        List<SeriesViewModel> Series { get; set; }
-    }
-
-    /// <summary>
     /// The default legend control, by default a new instance of this control is created for every chart that requires a legend.
     /// </summary>
     public partial class DefaultLegend : IChartLegend

--- a/UwpView/DefaultTooltip.xaml.cs
+++ b/UwpView/DefaultTooltip.xaml.cs
@@ -33,35 +33,6 @@ using LiveCharts.Uwp.Components;
 namespace LiveCharts.Uwp
 {
     /// <summary>
-    /// 
-    /// </summary>
-    /// <seealso cref="System.ComponentModel.INotifyPropertyChanged" />
-    public interface IChartTooltip : INotifyPropertyChanged
-    {
-        /// <summary>
-        /// Gets or sets the data.
-        /// </summary>
-        /// <value>
-        /// The data.
-        /// </value>
-        TooltipData Data { get; set; }
-        /// <summary>
-        /// Gets or sets the selection mode.
-        /// </summary>
-        /// <value>
-        /// The selection mode.
-        /// </value>
-        TooltipSelectionMode SelectionMode { get; set; }
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is wrapped.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if this instance is wrapped; otherwise, <c>false</c>.
-        /// </value>
-        bool IsWrapped { get; set; }
-    }
-
-    /// <summary>
     /// The Default Tooltip control, by default any chart that requires a tooltip will create a new instance of this class.
     /// </summary>
     public partial class DefaultTooltip : IChartTooltip

--- a/UwpView/IChartLegend.cs
+++ b/UwpView/IChartLegend.cs
@@ -1,0 +1,40 @@
+//The MIT License(MIT)
+
+//copyright(c) 2016 Alberto Rodriguez
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+using System.Collections.Generic;
+
+namespace LiveCharts.Uwp
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IChartLegend
+    {
+        /// <summary>
+        /// Gets or sets the series.
+        /// </summary>
+        /// <value>
+        /// The series.
+        /// </value>
+        List<SeriesViewModel> Series { get; set; }
+    }
+}

--- a/UwpView/IChartTooltip.cs
+++ b/UwpView/IChartTooltip.cs
@@ -1,0 +1,55 @@
+//The MIT License(MIT)
+
+//copyright(c) 2016 Alberto Rodriguez
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+using System.ComponentModel;
+
+namespace LiveCharts.Uwp
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <seealso cref="System.ComponentModel.INotifyPropertyChanged" />
+    public interface IChartTooltip : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Gets or sets the data.
+        /// </summary>
+        /// <value>
+        /// The data.
+        /// </value>
+        TooltipData Data { get; set; }
+        /// <summary>
+        /// Gets or sets the selection mode.
+        /// </summary>
+        /// <value>
+        /// The selection mode.
+        /// </value>
+        TooltipSelectionMode SelectionMode { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is wrapped.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is wrapped; otherwise, <c>false</c>.
+        /// </value>
+        bool IsWrapped { get; set; }
+    }
+}

--- a/UwpView/UwpView.csproj
+++ b/UwpView/UwpView.csproj
@@ -163,6 +163,8 @@
       <DependentUpon>HeatColorRange.xaml</DependentUpon>
     </Compile>
     <Compile Include="HeatSeries.cs" />
+    <Compile Include="IChartLegend.cs" />
+    <Compile Include="IChartTooltip.cs" />
     <Compile Include="LineSegmentSplitter.cs" />
     <Compile Include="LineSeries.cs" />
     <Compile Include="Maps\MapResolver.cs" />

--- a/WpfView/DefaultLegend.xaml.cs
+++ b/WpfView/DefaultLegend.xaml.cs
@@ -31,21 +31,6 @@ using System.Windows.Data;
 namespace LiveCharts.Wpf
 {
     /// <summary>
-    /// 
-    /// </summary>
-    /// <seealso cref="System.ComponentModel.INotifyPropertyChanged" />
-    public interface IChartLegend : INotifyPropertyChanged
-    {
-        /// <summary>
-        /// Gets or sets the series.
-        /// </summary>
-        /// <value>
-        /// The series.
-        /// </value>
-        List<SeriesViewModel> Series { get; set; }
-    }
-
-    /// <summary>
     /// The default legend control, by default a new instance of this control is created for every chart that requires a legend.
     /// </summary>
     public partial class DefaultLegend : IChartLegend

--- a/WpfView/DefaultTooltip.xaml
+++ b/WpfView/DefaultTooltip.xaml
@@ -33,9 +33,6 @@
              mc:Ignorable="d" 
              d:DataContext="{d:DesignInstance wpf:DefaultTooltip}"
              BorderThickness="1.3">
-    <UserControl.Background>
-        <SolidColorBrush Color="#202020" Opacity=".8" />
-    </UserControl.Background>
     <UserControl.Resources>
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="{Binding Foreground}"></Setter>

--- a/WpfView/DefaultTooltip.xaml
+++ b/WpfView/DefaultTooltip.xaml
@@ -32,7 +32,7 @@
              xmlns:wpf="clr-namespace:LiveCharts.Wpf"
              mc:Ignorable="d" 
              d:DataContext="{d:DesignInstance wpf:DefaultTooltip}"
-             BorderThickness="1.3">
+             x:Name="Control">
     <UserControl.Resources>
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="{Binding Foreground}"></Setter>
@@ -41,44 +41,59 @@
         <wpf:SharedVisibilityConverter x:Key="SharedVisibilityConverter"/>
         <wpf:ChartPointLabelConverter x:Key="ChartPointLabelConverter"/>
         <wpf:ParticipationVisibilityConverter x:Key="ParticipationVisibilityConverter"/>
+        <BooleanToVisibilityConverter x:Key="Bvc"></BooleanToVisibilityConverter>
     </UserControl.Resources>
     <UserControl.Template>
         <ControlTemplate>
-            <Border Background="{Binding Background}" CornerRadius="{Binding CornerRadius}"
-                    BorderThickness="{Binding BorderThickness}" Padding="10 5">
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="{Binding Data, Converter={StaticResource SharedConverter}}" HorizontalAlignment="Center" FontWeight="Bold"
-                               Visibility="{Binding Data, Converter={StaticResource SharedVisibilityConverter}}" />
-                    <ItemsControl ItemsSource="{Binding Data.Points}" Grid.IsSharedSizeScope="True">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate DataType="{x:Type wpf:DataPointViewModel}">
-                                <Grid Margin="2">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Title"/>
-                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
-                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Participation"/>
-                                    </Grid.ColumnDefinitions>
-                                    <Path Width="{Binding BulletSize, RelativeSource={RelativeSource Mode=FindAncestor, AncestorLevel=1, AncestorType={x:Type UserControl}}}" 
+            <Grid VerticalAlignment="Center" HorizontalAlignment="Center">
+                <Border Background="{Binding Background}" BorderThickness="1" Effect="{Binding Effect}" CornerRadius="{Binding CornerRadius}"
+                        Width="{Binding Width}" Height="{Binding Height}"/>
+                <Border Background="{Binding Background}" CornerRadius="{Binding CornerRadius}"
+                        BorderThickness="{Binding BorderThickness}" Padding="5"
+                        BorderBrush="{Binding BorderBrush}"
+                        Width="{Binding Width}" Height="{Binding Height}">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock Text="{Binding Data, Converter={StaticResource SharedConverter}}" HorizontalAlignment="Center" FontWeight="Bold">
+                            <TextBlock.Visibility>
+                                <MultiBinding Converter="{StaticResource SharedVisibilityConverter}">
+                                    <Binding Path="Data"></Binding>
+                                    <Binding Path="ShowTitle"></Binding>
+                                </MultiBinding>
+                            </TextBlock.Visibility>
+                        </TextBlock>
+                        <ItemsControl ItemsSource="{Binding Data.Points}" Grid.IsSharedSizeScope="True">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type wpf:DataPointViewModel}">
+                                    <Grid Margin="2" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto" SharedSizeGroup="Title"/>
+                                            <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+                                            <ColumnDefinition Width="Auto" SharedSizeGroup="Participation"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Path Width="{Binding BulletSize, RelativeSource={RelativeSource Mode=FindAncestor, AncestorLevel=1, AncestorType={x:Type UserControl}}}" 
                                              Height="{Binding BulletSize, RelativeSource={RelativeSource Mode=FindAncestor, AncestorLevel=1, AncestorType={x:Type UserControl}}}" 
                                              StrokeThickness="{Binding Series.StrokeThickness}" 
                                              Stroke="{Binding Series.Stroke}" Fill="{Binding Series.Fill}" 
-                                             Stretch="Fill" Data="{Binding Series.PointGeometry}"/>
-                                    <TextBlock Grid.Column="1" Text="{Binding Series.Title}" VerticalAlignment="Center" Margin="5 0 0 0"/>
-                                    
-                                    <TextBlock Grid.Column="2" Text="{Binding ChartPoint, Converter={StaticResource ChartPointLabelConverter}}" Margin="5 0 0 0" VerticalAlignment="Center"/>
+                                             Stretch="Fill" Data="{Binding Series.PointGeometry}"
+                                             Visibility="{Binding ShowSeries, ElementName=Control, Converter={StaticResource Bvc}}"/>
+                                        <TextBlock Grid.Column="1" Text="{Binding Series.Title}" VerticalAlignment="Center" Margin="5 0 5 0"
+                                                   Visibility="{Binding ShowSeries, ElementName=Control, Converter={StaticResource Bvc}}"/>
 
-                                    <TextBlock Grid.Column="3" Text="{Binding ChartPoint.Participation, StringFormat={}{0:P}}" 
+                                        <TextBlock Grid.Column="2" Text="{Binding ChartPoint, Converter={StaticResource ChartPointLabelConverter}}" VerticalAlignment="Center"/>
+
+                                        <TextBlock Grid.Column="3" Text="{Binding ChartPoint.Participation, StringFormat={}{0:P}}" 
                                                VerticalAlignment="Center" Margin="5 0 0 0"
                                                Visibility="{Binding DataContext.Data, RelativeSource={RelativeSource  FindAncestor, 
                                                                                                     AncestorType={x:Type StackPanel}}, 
                                                                     Converter={StaticResource ParticipationVisibilityConverter}}"/>
-                                </Grid>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </StackPanel>
-            </Border>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </ControlTemplate>
     </UserControl.Template>
 </UserControl>

--- a/WpfView/DefaultTooltip.xaml.cs
+++ b/WpfView/DefaultTooltip.xaml.cs
@@ -31,36 +31,6 @@ using System.Windows.Media;
 
 namespace LiveCharts.Wpf
 {
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <seealso cref="System.ComponentModel.INotifyPropertyChanged" />
-    public interface IChartTooltip : INotifyPropertyChanged
-    {
-        /// <summary>
-        /// Gets or sets the data.
-        /// </summary>
-        /// <value>
-        /// The data.
-        /// </value>
-        TooltipData Data { get; set; }
-        /// <summary>
-        /// Gets or sets the selection mode.
-        /// </summary>
-        /// <value>
-        /// The selection mode.
-        /// </value>
-        TooltipSelectionMode? SelectionMode { get; set; }
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is wrapped.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if this instance is wrapped; otherwise, <c>false</c>.
-        /// </value>
-        bool IsWrapped { get; set; }
-    }
-
     /// <summary>
     /// The Default Tooltip control, by default any chart that requires a tooltip will create a new instance of this class.
     /// </summary>
@@ -79,6 +49,15 @@ namespace LiveCharts.Wpf
             SetValue(CornerRadiusProperty, 4d);
 
             DataContext = this;
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="DefaultTooltip"/> class.
+        /// </summary>
+        static DefaultTooltip()
+        {
+            BackgroundProperty.OverrideMetadata(
+                typeof(DefaultTooltip), new FrameworkPropertyMetadata(Brushes.Black));
         }
 
         /// <summary>

--- a/WpfView/IChartLegend.cs
+++ b/WpfView/IChartLegend.cs
@@ -1,0 +1,42 @@
+﻿//The MIT License(MIT)
+
+//copyright(c) 2016 Alberto Rodriguez
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace LiveCharts.Wpf
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <seealso cref="System.ComponentModel.INotifyPropertyChanged" />
+    public interface IChartLegend : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Gets or sets the series.
+        /// </summary>
+        /// <value>
+        /// The series.
+        /// </value>
+        List<SeriesViewModel> Series { get; set; }
+    }
+}

--- a/WpfView/IChartTooltip.cs
+++ b/WpfView/IChartTooltip.cs
@@ -1,0 +1,55 @@
+//The MIT License(MIT)
+
+//copyright(c) 2016 Alberto Rodriguez
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+using System.ComponentModel;
+
+namespace LiveCharts.Wpf
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <seealso cref="System.ComponentModel.INotifyPropertyChanged" />
+    public interface IChartTooltip : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Gets or sets the data.
+        /// </summary>
+        /// <value>
+        /// The data.
+        /// </value>
+        TooltipData Data { get; set; }
+        /// <summary>
+        /// Gets or sets the selection mode.
+        /// </summary>
+        /// <value>
+        /// The selection mode.
+        /// </value>
+        TooltipSelectionMode? SelectionMode { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is wrapped.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is wrapped; otherwise, <c>false</c>.
+        /// </value>
+        bool IsWrapped { get; set; }
+    }
+}

--- a/WpfView/WpfView.csproj
+++ b/WpfView/WpfView.csproj
@@ -92,6 +92,8 @@
     <Compile Include="AngularSection.cs" />
     <Compile Include="ColorsCollection.cs" />
     <Compile Include="Components\IFondeable.cs" />
+    <Compile Include="IChartLegend.cs" />
+    <Compile Include="IChartTooltip.cs" />
     <Compile Include="ScatterSeries.cs" />
     <Compile Include="DefaultGeoMapTooltip.xaml.cs">
       <DependentUpon>DefaultGeoMapTooltip.xaml</DependentUpon>


### PR DESCRIPTION
#### Summary

DefualtTooltip got some design improvements, fixed some bugs, and it is now more flexible

This is the default look of it now
![new](https://cloud.githubusercontent.com/assets/10853349/21864795/0805fb96-d809-11e6-8e0c-388e3d8575ba.gif)

And you can now change drastically its look without the need of creating your own control:

![new](https://cloud.githubusercontent.com/assets/10853349/21864867/45bc3536-d809-11e6-8669-8413df84317b.gif)

```xml
<lvc:CartesianChart>
        <lvc:CartesianChart.Resources>
            <Style TargetType="lvc:DefaultTooltip">
                <Setter Property="Background" Value="DarkOrange"></Setter>
                <Setter Property="Foreground" Value="White"></Setter>
                <Setter Property="ShowTitle" Value="False"></Setter><!--new property-->
                <Setter Property="ShowSeries" Value="False"></Setter><!--new property-->
                <Setter Property="FontSize" Value="16"></Setter>
                <Setter Property="FontWeight" Value="Bold"></Setter>
                <Setter Property="CornerRadius" Value="20"></Setter>
                <Setter Property="Width" Value="40"></Setter>
                <Setter Property="Height" Value="40"></Setter>
                <Setter Property="BorderThickness" Value="0"></Setter>
            </Style>
        </lvc:CartesianChart.Resources>
        <lvc:CartesianChart.Series>
            <lvc:LineSeries Values="4,2,6,4"></lvc:LineSeries>
        </lvc:CartesianChart.Series>
    </lvc:CartesianChart>
```

#### Solves 

* Fixes an issue where DefaultTooltip background was not set properly when using styles