### PR TITLE
Fixed NullPointerException in case DrawsHeatRange = false

### DIFF
--- a/WpfView/HeatSeries.cs
+++ b/WpfView/HeatSeries.cs
@@ -259,6 +259,9 @@ namespace LiveCharts.Wpf
         /// </summary>
         public override void PlaceSpecializedElements()
         {
+            if (!DrawsHeatRange)
+            { return; }
+
             ColorRangeControl.UpdateFill(GradientStopCollection);
 
             ColorRangeControl.Height = Model.Chart.DrawMargin.Height;


### PR DESCRIPTION
#### Summary

NullPointerException in case DrawsHeatRange = false

To Reproduce:
xaml:

```
 <Window x:Class="WpfApplication1.MainWindow"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
        xmlns:local="clr-namespace:WpfApplication1"
        xmlns:lvc="clr-namespace:LiveCharts.Wpf;assembly=LiveCharts.Wpf"
        mc:Ignorable="d"
        Title="MainWindow" Height="350" Width="525">
    <Grid>
        
        <DockPanel LastChildFill="True" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" >
            <Button x:Name="AddStuff" Click="AddHeatMap">Press me</Button>
            <lvc:CartesianChart LegendLocation="None" DisableAnimations="True"  x:Name="Chart" >            
            </lvc:CartesianChart>
        </DockPanel>
    </Grid>
</Window>
````

Code Behind:
```
        private void AddHeatMap(object sender, RoutedEventArgs e)
        {
            var charValues = new ChartValues<HeatPoint>();
            var rand = new Random();
            for (int d = 0; d < 400; d++)
            {
                charValues.Add(new HeatPoint(d % 50, d / 50, rand.NextDouble()));
            }

            var s = new HeatSeries();
            s.Values = charValues;
            this.Chart.Series.Add(s);
            this.Chart.LegendLocation = LegendLocation.None;
            this.Chart.HideLegend();
            s.DrawsHeatRange = false;
        }`
```
#### Solves 

- The null pointer execption by not trying to draw, if it should not be drawn. (could have also checked if  ```ColorRangeControl!= null```) This solution seems better, since no one will ask "But why could it be null"
