### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ But that is not all, we try to support as many charts as possible, bars, lines, 
  - [ ] Xamarin
 - [ ] Release 1.0 in WPF and WinForms, the other platforms will be beta, in case something went wrong.
 
-###Support
+### Support
 
 WPF and Winforms, currenlty the library is in the process to become a cross net library...
 
-###Net Version
+### Net Version
 
 .Net 4.0 or greater
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
