### PR TITLE
Fix int overflow for large x values (e.g. DateTime.Ticks) #534

### DIFF
--- a/Core/AxisCore.cs
+++ b/Core/AxisCore.cs
@@ -531,7 +531,7 @@ namespace LiveCharts
 
             if (x < 0) x *= -1;
             return Labels.Count > x && x >= 0
-                ? Labels[(int)x]
+                ? Labels[checked((int)x)]
                 : "";
         }
 

--- a/Core/Charts/ChartCore.cs
+++ b/Core/Charts/ChartCore.cs
@@ -21,7 +21,6 @@
 //SOFTWARE.
 
 using System;
-using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
 using LiveCharts.Definitions.Charts;
@@ -667,15 +666,15 @@ namespace LiveCharts.Charts
                     if (mostLeft < ax.BotLimit)
                         // ReSharper disable once CompareOfFloatsByEqualityOperator
                         if (double.IsNaN(ax.MinValue))
-                            ax.BotLimit = mostLeft == 0
-                                ? 0
-                                : ((int) (mostLeft/ax.S) - 1)*ax.S;
+                            ax.BotLimit = mostLeft == 0.0
+                                ? 0.0
+                                : Math.Floor(mostLeft/ax.S)*ax.S;
                     if (mostRight > ax.TopLimit)
                         // ReSharper disable once CompareOfFloatsByEqualityOperator
                         if (double.IsNaN(ax.MaxValue))
-                            ax.TopLimit = mostRight == 0
-                                ? 0
-                                : ((int) (mostRight/ax.S) + 1)*ax.S;
+                            ax.TopLimit = mostRight == 0.0
+                                ? 0.0
+                                : (Math.Floor(mostRight/ax.S) + 1.0) *ax.S;
                 }
             }
 
@@ -693,15 +692,15 @@ namespace LiveCharts.Charts
                     if (mostLeft < ay.BotLimit)
                         // ReSharper disable once CompareOfFloatsByEqualityOperator
                         if (double.IsNaN(ay.MinValue))
-                            ay.BotLimit = mostLeft == 0
-                                ? 0
-                                : ((int) (mostLeft/ay.S) - 1)*ay.S;
+                            ay.BotLimit = mostLeft == 0.0
+                                ? 0.0
+                                : Math.Floor(mostLeft/ay.S)*ay.S;
                     if (mostRight > ay.TopLimit)
                         // ReSharper disable once CompareOfFloatsByEqualityOperator
                         if (double.IsNaN(ay.MaxValue))
-                            ay.TopLimit = mostRight == 0
-                                ? 0
-                                : ((int) (mostRight/ay.S) + 1)*ay.S;
+                            ay.TopLimit = mostRight == 0.0
+                                ? 0.0
+                                : (Math.Floor(mostRight/ay.S) + 1.0) *ay.S;
                 }
             }
         }

--- a/Core/Defaults/AxisLimits.cs
+++ b/Core/Defaults/AxisLimits.cs
@@ -38,27 +38,27 @@ namespace LiveCharts.Defaults
 
         internal static double UnitRight(AxisCore axis)
         {
-            return Math.Ceiling(axis.TopLimit/axis.Magnitude)*axis.Magnitude + 1;
+            return Math.Ceiling(axis.TopLimit/axis.Magnitude)*axis.Magnitude + 1.0;
         }
 
         internal static double UnitLeft(AxisCore axis)
         {
-            return Math.Floor(axis.BotLimit/axis.Magnitude)*axis.Magnitude - 1;
+            return Math.Floor(axis.BotLimit/axis.Magnitude)*axis.Magnitude - 1.0;
         }
 
         internal static double SeparatorMax(AxisCore axis)
         {
-            return ((int) (axis.TopLimit/axis.S) + 1)*axis.S;
+            return (Math.Floor(axis.TopLimit/axis.S) + 1.0)*axis.S;
         }
 
         internal static double SeparatorMaxRounded(AxisCore axis)
         {
-            return Math.Round((axis.TopLimit/axis.S) + 1, 0)*axis.S;
+            return Math.Round((axis.TopLimit/axis.S) + 1.0, 0)*axis.S;
         }
 
         internal static double SeparatorMin(AxisCore axis)
         {
-            return (((int) (axis.BotLimit/axis.S)) - 1)*axis.S;
+            return (Math.Floor(axis.BotLimit/axis.S) - 1.0)*axis.S;
         }
     }
 }

--- a/Core40/Charts/ChartCore.cs
+++ b/Core40/Charts/ChartCore.cs
@@ -667,15 +667,15 @@ namespace LiveCharts.Charts
                     if (mostLeft < ax.BotLimit)
                         // ReSharper disable once CompareOfFloatsByEqualityOperator
                         if (double.IsNaN(ax.MinValue))
-                            ax.BotLimit = mostLeft == 0
-                                ? 0
-                                : ((int) (mostLeft/ax.S) - 1)*ax.S;
+                            ax.BotLimit = mostLeft == 0.0
+                                ? 0.0
+                                : (Math.Floor(mostLeft/ax.S) - 1.0)*ax.S;
                     if (mostRight > ax.TopLimit)
                         // ReSharper disable once CompareOfFloatsByEqualityOperator
                         if (double.IsNaN(ax.MaxValue))
-                            ax.TopLimit = mostRight == 0
-                                ? 0
-                                : ((int) (mostRight/ax.S) + 1)*ax.S;
+                            ax.TopLimit = mostRight == 0.0
+                                ? 0.0
+                                : (Math.Floor(mostRight/ax.S) + 1.0)*ax.S;
                 }
             }
 
@@ -693,15 +693,15 @@ namespace LiveCharts.Charts
                     if (mostLeft < ay.BotLimit)
                         // ReSharper disable once CompareOfFloatsByEqualityOperator
                         if (double.IsNaN(ay.MinValue))
-                            ay.BotLimit = mostLeft == 0
-                                ? 0
-                                : ((int) (mostLeft/ay.S) - 1)*ay.S;
+                            ay.BotLimit = mostLeft == 0.0
+                                ? 0.0
+                                : (Math.Floor(mostLeft/ay.S) - 1.0)*ay.S;
                     if (mostRight > ay.TopLimit)
                         // ReSharper disable once CompareOfFloatsByEqualityOperator
                         if (double.IsNaN(ay.MaxValue))
-                            ay.TopLimit = mostRight == 0
-                                ? 0
-                                : ((int) (mostRight/ay.S) + 1)*ay.S;
+                            ay.TopLimit = mostRight == 0.0
+                                ? 0.0
+                                : (Math.Floor(mostRight/ay.S) + 1.0)*ay.S;
                 }
             }
         }

--- a/Core40/Defaults/AxisLimits.cs
+++ b/Core40/Defaults/AxisLimits.cs
@@ -48,17 +48,17 @@ namespace LiveCharts.Defaults
 
         internal static double SeparatorMax(AxisCore axis)
         {
-            return ((int) (axis.TopLimit/axis.S) + 1)*axis.S;
+            return (Math.Floor(axis.TopLimit/axis.S) + 1.0)*axis.S;
         }
 
         internal static double SeparatorMaxRounded(AxisCore axis)
         {
-            return Math.Round((axis.TopLimit/axis.S) + 1, 0)*axis.S;
+            return Math.Round((axis.TopLimit/axis.S) + 1.0, 0)*axis.S;
         }
 
         internal static double SeparatorMin(AxisCore axis)
         {
-            return (((int) (axis.BotLimit/axis.S)) - 1)*axis.S;
+            return ((Math.Floor(axis.BotLimit/axis.S)) - 1.0)*axis.S;
         }
     }
 }

--- a/Core40/WindowAxisCore.cs
+++ b/Core40/WindowAxisCore.cs
@@ -99,10 +99,13 @@ namespace LiveCharts
             IAxisWindow proposedWindow = AxisWindows.EmptyWindow;
 
             // Build a range of possible separator indices
-            var rangeIndices = Enumerable.Range((int)Math.Floor(BotLimit), (int)Math.Floor(TopLimit - (EvaluatesUnitWidth ? unit : 0) - BotLimit)).Select(i => (double)i).ToList();
-
+            var start = (long) Math.Floor(BotLimit);
+            var count = (long) Math.Floor(TopLimit - (EvaluatesUnitWidth ? unit : 0.0) - BotLimit);
+            var end = start + count - 1;
+            var rangeIndices = LongRange(start, end).Select(i => (double)i);
+            
             // Make sure we have at least 2 separators to show
-            if (Windows != null && rangeIndices.Count > 1)
+            if (Windows != null && count > 1)
             {
                 foreach (var window in Windows)
                 {
@@ -118,7 +121,7 @@ namespace LiveCharts
                     // It might be it does not respect the supportedSeparatorCount parameter.
                     separatorIndices = proposedSeparatorIndices.ToList();
                     if (supportedSeparatorCount < separatorIndices.Count) continue;
-                    
+
                     // Pick this window. It is the first who passed both validations and our best candidate
                     proposedWindow = window;
                     break;
@@ -137,6 +140,14 @@ namespace LiveCharts
             SelectedWindow = proposedWindow;
 
             return separatorIndices;
+        }
+
+        private IEnumerable<long> LongRange(long start, long end)
+        {
+            for (long i = start; i <= end; i++)
+            {
+                yield return i;
+            }
         }
 
         private void DrawSeparator(double x, double tolerance, CoreMargin currentMargin, AxisOrientation source)


### PR DESCRIPTION
Fix int overflow for large x values (e.g. DateTime.Ticks) #534

#### Summary

Fix int overflow for large x values (e.g. DateTime.Ticks) and remove one List<> allocation for an iterator instead. It would also help to add checked arithmetic setting to the project settings, but this is not included to this PR.

#### Solves 

issue #534