### PR TITLE
Using ChartPoint's fill when available in ColumnSeries

### DIFF
--- a/WpfView/ColumnSeries.cs
+++ b/WpfView/ColumnSeries.cs
@@ -161,6 +161,8 @@ namespace LiveCharts.Wpf
             }
 
             pbv.Rectangle.Fill = Fill;
+            if (point.Fill != null) pbv.Rectangle.Fill = (Brush)point.Fill;
+
             pbv.Rectangle.StrokeThickness = StrokeThickness;
             pbv.Rectangle.Stroke = Stroke;
             pbv.Rectangle.StrokeDashArray = StrokeDashArray;


### PR DESCRIPTION
#### Summary
Fixed mappers not affecting columns' fill

#### Solves 

[#641](https://github.com/beto-rodriguez/Live-Charts/issues/641)
