### PR TITLE
648 axissection label not cleared

### DIFF
--- a/WpfView/AxisSection.cs
+++ b/WpfView/AxisSection.cs
@@ -30,6 +30,7 @@ using LiveCharts.Definitions.Charts;
 using LiveCharts.Dtos;
 using LiveCharts.Helpers;
 using LiveCharts.Wpf.Charts.Base;
+using System.Diagnostics;
 
 namespace LiveCharts.Wpf
 {
@@ -389,9 +390,10 @@ namespace LiveCharts.Wpf
         /// </summary>
         public void Remove()
         {
-            Model.Chart.View.RemoveFromView(this);
-            Model.Chart.View.RemoveFromDrawMargin(_rectangle);
             Model.Chart.View.RemoveFromDrawMargin(_label);
+            Model.Chart.View.RemoveFromView(_label);
+            Model.Chart.View.RemoveFromDrawMargin(_rectangle);
+            Model.Chart.View.RemoveFromView(this);
         }
 
         /// <summary>

--- a/WpfView/AxisSection.cs
+++ b/WpfView/AxisSection.cs
@@ -30,7 +30,6 @@ using LiveCharts.Definitions.Charts;
 using LiveCharts.Dtos;
 using LiveCharts.Helpers;
 using LiveCharts.Wpf.Charts.Base;
-using System.Diagnostics;
 
 namespace LiveCharts.Wpf
 {


### PR DESCRIPTION
#### Summary

Added call to `RemoveFromView` for `_label` as `RemoveFromDrawMargin` did not seem sufficient to remove the label

#### Solves 

[648](https://github.com/beto-rodriguez/Live-Charts/issues/648)
