### PR TITLE
652 financial coloring rules broken

### DIFF
--- a/Core40/SeriesAlgorithms/CandleAlgorithm.cs
+++ b/Core40/SeriesAlgorithms/CandleAlgorithm.cs
@@ -68,6 +68,8 @@ namespace LiveCharts.SeriesAlgorithms
                 candleWidth = totalSpace;
             }
 
+            ChartPoint previousDrawn = null;
+
             foreach (var chartPoint in View.ActualValues.GetPoints(View))
             {
                 var x = ChartFunctions.ToDrawMargin(chartPoint.X, AxisOrientation.X, Chart, View.ScalesXAt);
@@ -90,7 +92,9 @@ namespace LiveCharts.SeriesAlgorithms
 
                 chartPoint.ChartLocation = new CorePoint(x + exceed/2, (candeView.High + candeView.Low)/2);
 
-                chartPoint.View.DrawOrMove(null, chartPoint, 0, Chart);
+                chartPoint.View.DrawOrMove(previousDrawn, chartPoint, 0, Chart);
+
+                previousDrawn = chartPoint;
             }
         }
 

--- a/WpfView/Points/CandlePointView.cs
+++ b/WpfView/Points/CandlePointView.cs
@@ -75,34 +75,8 @@ namespace LiveCharts.Wpf.Points
                 Canvas.SetTop(HoverShape, High);
             }
 
-            if (chart.View.DisableAnimations)
-            {
-                HighToLowLine.Y1 = High;
-                HighToLowLine.Y2 = Low;
-                HighToLowLine.X1 = center;
-                HighToLowLine.X2 = center;
 
-                OpenToCloseRectangle.Width = Width;
-                OpenToCloseRectangle.Height = Math.Abs(Open - Close);
-
-                Canvas.SetTop(OpenToCloseRectangle, Math.Min(Open, Close));
-                Canvas.SetLeft(OpenToCloseRectangle, Left);
-
-                if (DataLabel != null)
-                {
-                    DataLabel.UpdateLayout();
-
-                    var cx = CorrectXLabel(current.ChartLocation.X - DataLabel.ActualHeight * .5, chart);
-                    var cy = CorrectYLabel(current.ChartLocation.Y - DataLabel.ActualWidth * .5, chart);
-
-                    Canvas.SetTop(DataLabel, cy);
-                    Canvas.SetLeft(DataLabel, cx);
-                }
-
-                return;
-            }
-
-            var candleSeries = (CandleSeries) current.SeriesView;
+            var candleSeries = (CandleSeries)current.SeriesView;
 
             if (candleSeries.ColoringRules == null)
             {
@@ -132,6 +106,36 @@ namespace LiveCharts.Wpf.Points
                     break;
                 }
             }
+
+
+            if (chart.View.DisableAnimations)
+            {
+                HighToLowLine.Y1 = High;
+                HighToLowLine.Y2 = Low;
+                HighToLowLine.X1 = center;
+                HighToLowLine.X2 = center;
+
+                OpenToCloseRectangle.Width = Width;
+                OpenToCloseRectangle.Height = Math.Abs(Open - Close);
+
+                Canvas.SetTop(OpenToCloseRectangle, Math.Min(Open, Close));
+                Canvas.SetLeft(OpenToCloseRectangle, Left);
+
+                if (DataLabel != null)
+                {
+                    DataLabel.UpdateLayout();
+
+                    var cx = CorrectXLabel(current.ChartLocation.X - DataLabel.ActualHeight * .5, chart);
+                    var cy = CorrectYLabel(current.ChartLocation.Y - DataLabel.ActualWidth * .5, chart);
+
+                    Canvas.SetTop(DataLabel, cy);
+                    Canvas.SetLeft(DataLabel, cx);
+                }
+
+                return;
+            }
+
+            
 
             var animSpeed = chart.View.AnimationsSpeed;
 


### PR DESCRIPTION
#### Summary

Changes solve the first two issues with issue #652 :
- Applies `FinancialColoringRules` even if animations are disabled
- Sends a reference to last point drawn to the point so that a candle can use the previous day's close compared to current to affect it's coloring

Does not solve the 3rd point: `GCandleSeries` is broken when trying to use `FinancialColoringRules`
