### PR TITLE
step lines chart looking incomplete when used with a column chart

### DIFF
--- a/WpfView/Points/StepLinePointView.cs
+++ b/WpfView/Points/StepLinePointView.cs
@@ -35,6 +35,7 @@ namespace LiveCharts.Wpf.Points
         public double DeltaY { get; set; }
         public Line Line1 { get; set; }
         public Line Line2 { get; set; }
+        public Line Line3 { get; set; }
         public Path Shape { get; set; }
 
         public override void DrawOrMove(ChartPoint previousDrawn, ChartPoint current, int index, ChartCore chart)
@@ -66,6 +67,20 @@ namespace LiveCharts.Wpf.Points
                     Line2.X2 = current.ChartLocation.X;
                     Line2.Y1 = chart.DrawMargin.Height;
                     Line2.Y2 = chart.DrawMargin.Height;
+                                      
+                }
+
+                if (index == current.SeriesView.Values.Count - 1)
+                {
+                    Line3.Visibility = System.Windows.Visibility.Visible;
+                    Line3.X1 = current.ChartLocation.X;
+                    Line3.X2 = current.ChartLocation.X + DeltaX;
+                    Line3.Y1 = chart.DrawMargin.Height;
+                    Line3.Y2 = chart.DrawMargin.Height;
+                }
+                else
+                {
+                    Line3.Visibility = System.Windows.Visibility.Collapsed;
                 }
 
                 if (Shape != null)
@@ -114,6 +129,20 @@ namespace LiveCharts.Wpf.Points
                     Line2.X2 = current.ChartLocation.X;
                     Line2.Y1 = current.ChartLocation.Y - DeltaY;
                     Line2.Y2 = current.ChartLocation.Y - DeltaY;
+                   
+                }
+
+                if (index == current.SeriesView.Values.Count - 1)
+                {
+                    Line3.Visibility = System.Windows.Visibility.Visible;
+                    Line3.X1 = current.ChartLocation.X;
+                    Line3.X2 = current.ChartLocation.X + DeltaX;
+                    Line3.Y1 = current.ChartLocation.Y;
+                    Line3.Y2 = current.ChartLocation.Y;
+                }
+                else
+                {
+                    Line3.Visibility = System.Windows.Visibility.Collapsed;
                 }
 
                 if (Shape != null)
@@ -175,6 +204,25 @@ namespace LiveCharts.Wpf.Points
                     new DoubleAnimation(current.ChartLocation.Y - DeltaY, animSpeed));
                 Line2.BeginAnimation(Line.Y2Property,
                     new DoubleAnimation(current.ChartLocation.Y - DeltaY, animSpeed));
+                
+            }
+
+            if (index == current.SeriesView.Values.Count - 1)
+            {
+                Line3.Visibility = System.Windows.Visibility.Visible;
+                Line3.BeginAnimation(Line.X1Property,
+                new DoubleAnimation(current.ChartLocation.X, animSpeed));
+                Line3.BeginAnimation(Line.X2Property,
+                new DoubleAnimation(current.ChartLocation.X + DeltaX, animSpeed));
+                Line3.BeginAnimation(Line.Y1Property,
+                new DoubleAnimation(current.ChartLocation.Y, animSpeed));
+                Line3.BeginAnimation(Line.Y2Property,
+                new DoubleAnimation(current.ChartLocation.Y, animSpeed));
+
+            }
+            else
+            {
+                Line3.Visibility = System.Windows.Visibility.Collapsed;
             }
 
             if (Shape != null)
@@ -203,6 +251,7 @@ namespace LiveCharts.Wpf.Points
             chart.View.RemoveFromDrawMargin(DataLabel);
             chart.View.RemoveFromDrawMargin(Line1);
             chart.View.RemoveFromDrawMargin(Line2);
+            chart.View.RemoveFromDrawMargin(Line3);
         }
 
         public override void OnHover(ChartPoint point)

--- a/WpfView/Points/StepLinePointView.cs
+++ b/WpfView/Points/StepLinePointView.cs
@@ -70,7 +70,7 @@ namespace LiveCharts.Wpf.Points
                                       
                 }
 
-                if (index == current.SeriesView.Values.Count - 1)
+                if (((StepLineSeries)current.SeriesView).ContinueLastLine && index == current.SeriesView.Values.Count - 1)
                 {
                     Line3.Visibility = System.Windows.Visibility.Visible;
                     Line3.X1 = current.ChartLocation.X;
@@ -132,7 +132,7 @@ namespace LiveCharts.Wpf.Points
                    
                 }
 
-                if (index == current.SeriesView.Values.Count - 1)
+                if (((StepLineSeries)current.SeriesView).ContinueLastLine && index == current.SeriesView.Values.Count - 1)
                 {
                     Line3.Visibility = System.Windows.Visibility.Visible;
                     Line3.X1 = current.ChartLocation.X;
@@ -207,7 +207,7 @@ namespace LiveCharts.Wpf.Points
                 
             }
 
-            if (index == current.SeriesView.Values.Count - 1)
+            if (((StepLineSeries)current.SeriesView).ContinueLastLine &&  index == current.SeriesView.Values.Count - 1)
             {
                 Line3.Visibility = System.Windows.Visibility.Visible;
                 Line3.BeginAnimation(Line.X1Property,

--- a/WpfView/StepLineSeries.cs
+++ b/WpfView/StepLineSeries.cs
@@ -133,6 +133,17 @@ namespace LiveCharts.Wpf
             set { SetValue(InvertedModeProperty, value); }
         }
 
+        public bool ContinueLastLine
+        {
+            get { return (bool)GetValue(ContinueLastLineProperty); }
+            set { SetValue(ContinueLastLineProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for ContinueLastLine.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty ContinueLastLineProperty =
+            DependencyProperty.Register("ContinueLastLine", typeof(bool), typeof(StepLineSeries), new PropertyMetadata(false, CallChartUpdater()));
+
+
         #endregion
 
         #region Overridden Methods

--- a/WpfView/StepLineSeries.cs
+++ b/WpfView/StepLineSeries.cs
@@ -154,10 +154,12 @@ namespace LiveCharts.Wpf
                     IsNew = true,
                     Line2 = new Line(),
                     Line1 = new Line()
+                    Line3 = new Line() { StrokeLineJoin = PenLineJoin.Miter, StrokeEndLineCap = PenLineCap.Square, StrokeStartLineCap = PenLineCap.Square }
                 };
 
                 Model.Chart.View.AddToDrawMargin(pbv.Line2);
                 Model.Chart.View.AddToDrawMargin(pbv.Line1);
+                Model.Chart.View.AddToDrawMargin(pbv.Line3);
                 Model.Chart.View.AddToDrawMargin(pbv.Shape);
             }
             else
@@ -173,6 +175,8 @@ namespace LiveCharts.Wpf
                     .EnsureElementBelongsToCurrentDrawMargin(pbv.Line2);
                 point.SeriesView.Model.Chart.View
                     .EnsureElementBelongsToCurrentDrawMargin(pbv.Line1);
+                point.SeriesView.Model.Chart.View
+                    .EnsureElementBelongsToCurrentDrawMargin(pbv.Line3);
             }
 
             pbv.Line1.StrokeThickness = StrokeThickness;
@@ -185,6 +189,12 @@ namespace LiveCharts.Wpf
             pbv.Line2.Stroke = Stroke;
             pbv.Line2.StrokeDashArray = StrokeDashArray;
             pbv.Line2.Visibility = Visibility;
+            Panel.SetZIndex(pbv.Line2, Panel.GetZIndex(this));
+
+            pbv.Line3.StrokeThickness = StrokeThickness;
+            pbv.Line3.Stroke = Stroke;
+            pbv.Line3.StrokeDashArray = StrokeDashArray;
+            pbv.Line3.Visibility = Visibility;
             Panel.SetZIndex(pbv.Line2, Panel.GetZIndex(this));
 
             if (PointGeometry != null && Math.Abs(PointGeometrySize) > 0.1 && pbv.Shape == null)


### PR DESCRIPTION
#### Summary

fix step lines chart looking incomplete when used with a column chart. Draw an additionnal horizontal line for the last chart point.

#### Solves 

 Part of issue #638
