### PR TITLE
Issue 687: NullReferenceException in LineSeries.Erase() when called b…

### DIFF
--- a/WpfView/LineSeries.cs
+++ b/WpfView/LineSeries.cs
@@ -349,7 +349,7 @@ namespace LiveCharts.Wpf
                     p.View.RemoveFromView(Model.Chart);
             });
             if (Path != null) Path.Visibility = Visibility.Hidden;
-            if (removeFromView)
+            if (removeFromView && Model.Chart != null)
             {
                 Model.Chart.View.RemoveFromDrawMargin(Path);
                 Model.Chart.View.RemoveFromView(this);


### PR DESCRIPTION
…y SeriesCollection.OnNoisyCollectionChanged() and SeriesCollection.Chart has not been set before

See https://github.com/beto-rodriguez/Live-Charts/issues/687

When a SeriesCollection is created without having it's Chart property set, and SeriesCollection.Clear() is calledm SeriesCollection.OnNoisyCollectionChanged() first sets the ILineSeriesView.Model.Chart to null for all oldItems and then calls ILineSeriesView.Erase(). At least for the LineSeries class this leads to a null reference exception in lines 354 or 355. 

This might also affect other parts of this class (and possibly other implementations of ILineSeriesView)

#### Summary

*Explain the changes in this PR*

#### Solves 

*List the issues this PR solves, blank if none*
