### PR TITLE
Fix crash when add an element to a collection already containing it

### DIFF
--- a/UwpView/Charts/Base/Chart.cs
+++ b/UwpView/Charts/Base/Chart.cs
@@ -720,7 +720,7 @@ namespace LiveCharts.Uwp.Charts.Base
         public void AddToView(object element)
         {
             var wpfElement = (FrameworkElement) element;
-            if (wpfElement == null) return;
+            if (wpfElement == null || Canvas.Children.Contains(wpfElement)) return;
             Canvas.Children.Add(wpfElement);
         }
 
@@ -731,7 +731,7 @@ namespace LiveCharts.Uwp.Charts.Base
         public void AddToDrawMargin(object element)
         {
             var wpfElement = (FrameworkElement) element;
-            if (wpfElement == null) return;
+            if (wpfElement == null || DrawMargin.Children.Contains(wpfElement)) return;
             DrawMargin.Children.Add(wpfElement);
         }
 


### PR DESCRIPTION
#### Summary

Fix crash when add an element to a collection already containing it.
This was happening when changing the bindings at runtime without disposing the view.

#### Solves 