### PR TITLE
Fixed a crash when HeatMap is set through binding instead of constructor

### DIFF
--- a/WpfView/GeoMap.cs
+++ b/WpfView/GeoMap.cs
@@ -381,6 +381,10 @@ namespace LiveCharts.Wpf
         /// <param name="value">new value</param>
         public void UpdateKey(string key, double value)
         {
+            if (HeatMap == null)
+            {
+              HeatMap = new Dictionary<string, double>();
+            }
             HeatMap[key] = value;
             ShowMeSomeHeat();
         }
@@ -482,6 +486,8 @@ namespace LiveCharts.Wpf
 
         private void ShowMeSomeHeat()
         {
+            if (HeatMap == null) return;
+
             var max = double.MinValue;
             var min = double.MaxValue;
 


### PR DESCRIPTION
I faced a crash with GeoMap at startup because the HeatMap was null in ShowMeSomeHeat method because it was called before the binding had a chance to set the property.