### PR TITLE
Disable Dpi Awareness in Winforms project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <a href="http://lvcharts.net/"><img src="http://lvcharts.net/Content/Images/LiveChartsWhite.gif" /></a>
 </p>
 
-# LiveCharts 1.0 is comming soon (ETA April 2018)!
+# LiveCharts 1.0 is comming soon (ETA ~~April~~ September 2018)!
 
 We are doing a full rewrite of the library with all the learned lessons, the new version is focused on:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # This project will continue in another repo, please see  [LiveCharts2](https://github.com/Live-Charts/LiveCharts2) for more info
 
-# ~~LiveCharts 1.0 is coming soon (ETA April~~ September 2018)!~~
+# ~~LiveCharts 1.0 is coming soon (ETA AprilSeptember 2018)!~~
 
 ~~We are doing a full rewrite of the library with all the learned lessons, the new version is focused on:~~
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <a href="http://lvcharts.net/"><img src="http://lvcharts.net/Content/Images/LiveChartsWhite.gif" /></a>
 </p>
 
-# LiveCharts 1.0 is comming soon (ETA April 2018)!
+# LiveCharts 1.0 is coming soon (ETA April 2018)!
 
 We are doing a full rewrite of the library with all the learned lessons, the new version is focused on:
 
@@ -73,10 +73,10 @@ But that is not all, we try to support as many charts as possible, bars, lines, 
 - [x] ~~Build at least all the features any other charting library does, in WPF and WinForms~~
 - [ ] **[In progress]** Build High performance algorithms 
 - [ ] **[In progress]** Expand the library to:
- - [x] ~~WPF~~
- - [x] ~~WinForms~~
- - [ ] UWP **[In progress]**
- - [ ] Xamarin
+    - [x] ~~WPF~~
+    - [x] ~~WinForms~~
+    - [ ] UWP **[In progress]**
+    - [ ] Xamarin
 - [ ] Release 1.0 in WPF and WinForms, the other platforms will be beta, in case something went wrong.
 
 ### Support
@@ -111,7 +111,7 @@ You can also buy me a beer
 <input type="image" src="https://www.paypalobjects.com/en_GB/i/btn/btn_donate_LG.gif" border="0" name="submit" alt="PayPal – The safer, easier way to pay online.">
 <img alt="" border="0" src="https://www.paypalobjects.com/es_XC/i/scr/pixel.gif" width="1" height="1">
 </form>
-[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=J86WDLSS9PWGL)
+[paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=J86WDLSS9PWGL)
 
 ### Examples?
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # LiveCharts 1.0 is comming soon (ETA April 2018)!
 
-We are doing a full rewrite of the library with all the learned lessons, the new version is focus on:
+We are doing a full rewrite of the library with all the learned lessons, the new version is focused on:
 
 * **If you own the Geared package** the new high performance version is already yours! thank you very much for all your support!
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
   <a href="http://lvcharts.net/"><img src="http://lvcharts.net/Content/Images/LiveChartsWhite.gif" /></a>
 </p>
 
+# LiveCharts 1.0 is comming soon (ETA April 2018)!
+
+We are doing a full rewrite of the library with all the learned lessons, the new version is focus on:
+
+* **If you own the Geared package** the new high performance version is already yours! thank you very much for all your support!
+
+* **Portability**: In version 0.x it was hard keep WPF, UWP and Winforms versions up to date, in the new version we extracted all the math to a dotnet core project, then we are working on 4 different platfomrs WPF, Xamarin, UWP and the new high performance package.
+* **Performance**: when the library started, performance was not the target, as the library community grow, the Geared package was released (the current high performance version), and it works for many cases, but we want LiveCharts to be the fastest library out there, in the new high performance package we are scaping from WPF performance limitations and drawing everything using DirectX with the well know [SharpDx](http://sharpdx.org/) package.
+* **3d**: 0.x layout was not designed to draw 3d plots, version 1.0 is really flexible and lucky we will be on 3d soon.
+* **Keep it easy!**: Even somethings might change, the idea of the library is the same, we only want to add support for the missing features and/or a better code quality so we can fix issues faster for all the platforms, all the samples will be updated with the new version.
+
+Check out our progress at [v1.0 branch](https://github.com/beto-rodriguez/Live-Charts/tree/v1.0).
+
 [![GitHub license](https://img.shields.io/github/license/beto-rodriguez/Live-Charts.svg?style=flat-square)](https://github.com/beto-rodriguez/Live-Charts/blob/master/LICENSE.TXT)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/707m8sye0ggbfrcq)](https://ci.appveyor.com/project/beto-rodriguez/live-charts)
 [![GitHub issues](https://img.shields.io/github/issues/beto-rodriguez/Live-Charts.svg?style=flat-square)](https://github.com/beto-rodriguez/Live-Charts/issues)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="http://lvcharts.net/"><img src="http://lvcharts.net/Content/Images/LiveChartsWhite.gif" /></a>
+  <a href="http://http://v0.lvcharts.com/"><img src="http://v0.lvcharts.com/Content/Images/LiveChartsWhite.gif" /></a>
 </p>
 
 # This project will continue in another repo, please see  [LiveCharts2](https://github.com/Live-Charts/LiveCharts2) for more info
@@ -26,7 +26,7 @@
 <a href="http://isitmaintained.com/project/beto-rodriguez/live-charts" title="Average time to resolve an issue"><img src="http://isitmaintained.com/badge/resolution/beto-rodriguez/live-charts.svg" alt="Average time to resolve an issue"></a>
 <a href="http://isitmaintained.com/project/beto-rodriguez/live-charts" title="Percentage of issues still open"><img src="http://isitmaintained.com/badge/open/beto-rodriguez/live-charts.svg" alt="Percentage of issues still open"></a>
 
-* **[Get Started Here](http://lvcharts.net/App/examples/wpf/start)**, this repository has many examples also.
+* **[Get Started Here](http://v0.lvcharts.com/App/examples/wpf/start)**, this repository has many examples also.
 * **[Chat](https://gitter.im/beto-rodriguez/Live-Charts)**
 * **Questions and support?**, we are always happy to help you at our chat, if you require so you can also try [Stack Overflow](http://stackoverflow.com/questions/tagged/livecharts).
 
@@ -36,13 +36,13 @@
 *images in this section are built with LiveCharts, but designed by [Kingyo](https://dribbble.com/Kingyo)*
 
 <p align="center">
-  <img src="http://lvcharts.net/Content/Images/materialcards.gif" />
+  <img src="http://v0.lvcharts.com/Content/Images/materialcards.gif" />
 </p>
 <p align="center">
-  <img src="http://lvcharts.net/Content/Images/energy.gif" />
+  <img src="http://v0.lvcharts.com/Content/Images/energy.gif" />
 </p>
 <p align="center">
-  <img src="http://lvcharts.net/Content/Images/solid.gif" />
+  <img src="http://v0.lvcharts.com/Content/Images/solid.gif" />
 </p>
 
 ### it is also
@@ -51,10 +51,10 @@
 As easy as manipulating any generic list in .Net, LiveCharts updates and animates as your data changes in real time, charts are also sensitive to size changes.
 
 <p align="center">
-  <img src="https://lvcharts.net/Content/Images/Banner/linq.gif" />
-  <img src="https://lvcharts.net/Content/Images/Banner/responsive.gif" />
-  <img src="https://lvcharts.net/Content/Images/Banner/doughnut.gif" />/
-  <img src="https://lvcharts.net/Content/Images/Banner/constant.gif" />
+  <img src="https://v0.lvcharts.com/Content/Images/Banner/linq.gif" />
+  <img src="https://v0.lvcharts.com/Content/Images/Banner/responsive.gif" />
+  <img src="https://v0.lvcharts.com/Content/Images/Banner/doughnut.gif" />/
+  <img src="https://v0.lvcharts.com/Content/Images/Banner/constant.gif" />
 </p>
 
 ### and of course it also is
@@ -63,13 +63,13 @@ As easy as manipulating any generic list in .Net, LiveCharts updates and animate
 LiveCharts is not just beauty charts, this example contains 100,000 points, and the chart is being refreshed constantly, we support zooming, panning, multiple axes, sections, merged UIelemnts and much more!
 
 <p align="center">
-  <img src="https://lvcharts.net/Content/Images/scrll.gif" />
+  <img src="https://v0.lvcharts.com/Content/Images/scrll.gif" />
 </p>
 
 But that is not all, we try to support as many charts as possible, bars, lines, heat maps, gauges, maps:
 
 <p align="center">
-  <img src="https://lvcharts.net/content/images/darkpanel.gif" />
+  <img src="https://v0.lvcharts.com/content/images/darkpanel.gif" />
 </p>
 
 ### Road Map
@@ -93,8 +93,8 @@ WPF and Winforms, currenlty the library is in the process to become a cross net 
 
 ### Installation
 
-* [Wpf](http://lvcharts.net/App/examples/wpf/Install)
-* [WinForms](http://lvcharts.net/App/examples/wf/Install)
+* [Wpf](http://v0.lvcharts.com/App/examples/wpf/Install)
+* [WinForms](http://v0.lvcharts.com/App/examples/wf/Install)
 
 ### Migrating from older versions?
 
@@ -119,7 +119,7 @@ You can also buy me a beer
 
 ### Examples?
 
-The [web site](http://lvcharts.net/App/examples/wpf/start) has a nice set, they are also built in the examples folder up here ^^^^
+The [web site](http://v0.lvcharts.com/App/examples/wpf/start) has a nice set, they are also built in the examples folder up here ^^^^
 
 ### Special thanks to
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,22 @@
   <a href="http://lvcharts.net/"><img src="http://lvcharts.net/Content/Images/LiveChartsWhite.gif" /></a>
 </p>
 
-# LiveCharts 1.0 is coming soon (ETA ~~April~~ September 2018)!
+# This project will continue in another repo, please see  [LiveCharts2](https://github.com/Live-Charts/LiveCharts2) for more info
 
-We are doing a full rewrite of the library with all the learned lessons, the new version is focused on:
+# ~~LiveCharts 1.0 is coming soon (ETA April~~ September 2018)!~~
 
-* **If you own the Geared package** the new high performance version is already yours! thank you very much for all your support!
+~~We are doing a full rewrite of the library with all the learned lessons, the new version is focused on:~~
 
-* **Portability**: In version 0.x it was hard keep WPF, UWP and Winforms versions up to date, in the new version we extracted all the math to a dotnet core project, then we are working on 4 different platfomrs WPF, Xamarin, UWP and the new high performance package.
-* **Performance**: when the library started, performance was not the target, as the library community grow, the Geared package was released (the current high performance version), and it works for many cases, but we want LiveCharts to be the fastest library out there, in the new high performance package we are scaping from WPF performance limitations and drawing everything using DirectX with the well know [SharpDx](http://sharpdx.org/) package.
-* **3d**: 0.x layout was not designed to draw 3d plots, version 1.0 is really flexible and lucky we will be on 3d soon.
-* **Keep it easy!**: Even somethings might change, the idea of the library is the same, we only want to add support for the missing features and/or a better code quality so we can fix issues faster for all the platforms, all the samples will be updated with the new version.
+~~* **If you own the Geared package** the new high performance version is already yours! thank you very much for all your support!~~
 
-Check out our progress at [v1.0 branch](https://github.com/beto-rodriguez/Live-Charts/tree/v1.0).
+~~* **Portability**: In version 0.x it was hard keep WPF, UWP and Winforms versions up to date, in the new version we extracted all the math to a dotnet core project, then we are working on 4 different platfomrs WPF, Xamarin, UWP and the new high performance package.~~
+
+~~* **Performance**: when the library started, performance was not the target, as the library community grow, the Geared package was released (the current high performance version), and it works for many cases, but we want LiveCharts to be the fastest library out there, in the new high performance package we are scaping from WPF performance limitations and drawing everything using DirectX with the well know [SharpDx](http://sharpdx.org/) package.~~
+
+~~* **3d**: 0.x layout was not designed to draw 3d plots, version 1.0 is really flexible and lucky we will be on 3d soon.~~
+~~* **Keep it easy!**: Even somethings might change, the idea of the library is the same, we only want to add support for the missing features and/or a better code quality so we can fix issues faster for all the platforms, all the samples will be updated with the new version.~~
+
+~~Check out our progress at [v1.0 branch](https://github.com/beto-rodriguez/Live-Charts/tree/v1.0).~~
 
 [![GitHub license](https://img.shields.io/github/license/beto-rodriguez/Live-Charts.svg?style=flat-square)](https://github.com/beto-rodriguez/Live-Charts/blob/master/LICENSE.TXT)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/707m8sye0ggbfrcq)](https://ci.appveyor.com/project/beto-rodriguez/live-charts)

--- a/WpfView/PieSeries.cs
+++ b/WpfView/PieSeries.cs
@@ -173,6 +173,9 @@ namespace LiveCharts.Wpf
                 pbv.DataLabel = null;
             }
 
+            if (point.Stroke != null) pbv.Slice.Stroke = (Brush)point.Stroke;
+            if (point.Fill != null) pbv.Slice.Fill = (Brush)point.Fill;
+
             pbv.OriginalPushOut  = PushOut;
 
             return pbv;

--- a/WpfView/StackedRowSeries.cs
+++ b/WpfView/StackedRowSeries.cs
@@ -215,6 +215,9 @@ namespace LiveCharts.Wpf
                 pbv.DataLabel = null;
             }
 
+            if (point.Stroke != null) pbv.Rectangle.Stroke = (Brush)point.Stroke;
+            if (point.Fill != null) pbv.Rectangle.Fill = (Brush)point.Fill;
+
             pbv.LabelPosition = LabelsPosition;
 
             return pbv;


### PR DESCRIPTION
#### Summary

Controls in Winforms have broken layout due to Dpi Awarness, 

"When WPF is loaded into a project, it promotes the process to be System DPI Aware"
source: https://stackoverflow.com/a/36344413/4542599

#### Solves 

Adding [assembly: DisableDpiAwareness] to AssemblyInfo fixes this problem
